### PR TITLE
External Links Should Be Able to Dereference NWB Objects

### DIFF
--- a/+types/+untyped/ExternalLink.m
+++ b/+types/+untyped/ExternalLink.m
@@ -12,14 +12,38 @@ classdef ExternalLink < handle
         
         function data = deref(obj)
             fid = H5F.open(obj.filename, 'H5F_ACC_RDONLY', 'H5P_DEFAULT');
+            info = h5info(obj.filename, obj.path);
+            loc = [obj.filename obj.path];
+            attr_names = {info.Attributes.Name};
+            
+            is_typed = any(strcmp(attr_names, 'neurodata_type')...
+                | strcmp(attr_names, 'namespace'));
+            
             oid = H5O.open(fid, obj.path, 'H5P_DEFAULT');
             oinfo = H5O.get_info(oid);
-            assert(oinfo.type == H5ML.get_constant_value('H5G_DATASET'),...
-                'Externally linked %s contains an unsupported type.',...
-                [obj.filename obj.path]);
-            data = H5D.read(oid);
+            
             H5O.close(oid);
             H5F.close(fid);
+            switch oinfo.type
+                case H5ML.get_constant_value('H5G_DATASET')
+                    if is_typed
+                        data = io.parseDataset(obj.filename, info, obj.path);
+                    else
+                        data = h5read(obj.filename, obj.path);
+                    end
+                case H5ML.get_constant_value('H5G_GROUP')
+                    if is_typed
+                        data = io.parseGroup(obj.filename, info);
+                    else
+                        error('Attempted to dereference an external link to a non-dataset object %s',...
+                            loc);
+                    end
+                case H5ML.get_constant_value('H5G_LINK')
+                    error('Attempted to dereference into another link %s.  Resolving Link chains is not implemented.', loc);
+                otherwise
+                    error('Externally linked %s contains an unsupported type.',...
+                        loc);
+            end
         end
         
         function refs = export(obj, fid, fullpath, refs)


### PR DESCRIPTION
Fixes #122 
This change will allow creating NWB types if possible.  Errors otherwise.
Unrfortunately, you do still have to NwbRead() the externally linked file in order to refresh ObjectView and RegionView objects derived from externally linked nwb files.  Unsure as to how to progress on that.