### PR TITLE
External Link deref expansion

### DIFF
--- a/+types/+untyped/ExternalLink.m
+++ b/+types/+untyped/ExternalLink.m
@@ -5,12 +5,26 @@ classdef ExternalLink < handle
     end
     
     methods
-        function obj = ExternalLink(filename, path)
+        function obj = ExternalLink(filename, varargin)
             obj.filename = filename;
-            obj.path = path;
+            if isempty(varargin)
+                obj.path = '';
+            else
+                obj.path = varargin{1};
+            end
         end
         
         function data = deref(obj)
+            % if path is valid hdf5 path, then returns either a Nwb Object, DataStub or a Link.
+            % otherwise, returns the file id of the referenced link.
+            assert(ischar(obj.filename), 'expecting filename to be a char array.');
+            assert(2 == exist(obj.filename, 'file'), '%s does not exist.', obj.filename);
+            
+            if isempty(obj.path)
+                data = fopen(obj.filename);
+                return;
+            end
+            
             fid = H5F.open(obj.filename, 'H5F_ACC_RDONLY', 'H5P_DEFAULT');
             info = h5info(obj.filename, obj.path);
             loc = [obj.filename obj.path];
@@ -29,20 +43,35 @@ classdef ExternalLink < handle
                     if is_typed
                         data = io.parseDataset(obj.filename, info, obj.path);
                     else
-                        data = h5read(obj.filename, obj.path);
+                        data = types.untyped.DataStub(obj.filename, obj.path);
                     end
                 case H5ML.get_constant_value('H5G_GROUP')
-                    if is_typed
-                        data = io.parseGroup(obj.filename, info);
-                    else
-                        error('Attempted to dereference an external link to a non-dataset object %s',...
-                            loc);
-                    end
+                    assert(is_typed,...
+                        ['Attempted to dereference an external link to '...
+                        'a non-dataset object %s'], loc);
+                    data = io.parseGroup(obj.filename, info);
                 case H5ML.get_constant_value('H5G_LINK')
-                    error('Attempted to dereference into another link %s.  Resolving Link chains is not implemented.', loc);
+                    data = deref_link(fid, obj.path);
                 otherwise
                     error('Externally linked %s contains an unsupported type.',...
                         loc);
+            end
+            
+            function data = deref_link(fid, path)
+                linfo = H5L.get_info(fid, path, 'H5P_DEFAULT');
+                is_external = linfo.type == H5ML.get_constant_value('H5L_TYPE_EXTERNAL');
+                is_soft = linfo.type == H5ML.get_constant_value('H5L_TYPE_SOFT');
+                assert(is_external || is_soft,...
+                    ['Unsupported link type in %s, with name %s.  '...
+                    'Links must be external or soft.'],...
+                    obj.filename, path);
+                
+                link_val = H5L.get_val(fid, path, 'H5P_DEFAULT');
+                if is_external
+                    data = types.untyped.ExternalLink(link_val{:});
+                else
+                    data = types.untyped.SoftLink(link_val{:});
+                end
             end
         end
         


### PR DESCRIPTION
Can now deref:
-  non-hdf5 files
-  links

Untyped datasets are now also coerced to DataStubs as they would normally be with typed datasets.