### PR TITLE
Make downloading of schema optional in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Download the current release of the NWB format schema from the [nwb-schema relea
 ```bash
 git clone --recursive https://github.com/NeurodataWithoutBorders/nwb-schema.git
 ```
-
+Then re-run `generateCore()` to update the API from the updated schema.
 ## API Documentation
 
 For more information regarding the MatNWB API or any of the NWB Core types in MatNWB, visit the [MatNWB API Documentation pages](https://neurodatawithoutborders.github.io/matnwb/doc/index.html).

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ git clone https://github.com/NeurodataWithoutBorders/matnwb.git
 
 ### Step 2: Generate the API
 
-From the Matlab command line, generate code from the copy of the NWB schema. The command also takes variable arguments from any extensions.
+From the Matlab command line, add MatNWB to the Matlab path and generate the core classes for the NWB schema.
 
 ```matlab
+cd matnwb
+addpath(genpath(pwd));
 generateCore(); % generate core namespace located in the repository.
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,24 +30,15 @@ This package reads and writes NWB:N 2.0 files and does not support older formats
 
 ## Setup
 
-#### Step 1: Download MatNWB
-[![View NeurodataWithoutBorders/matnwb on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://www.mathworks.com/matlabcentral/fileexchange/67741-neurodatawithoutborders-matnwb)
+### Step 1: Download MatNWB
 
-Download the current release of MatNWB from https://github.com/NeurodataWithoutBorders/matnwb/releases or check out the latest development version via 
+Download the current release of MatNWB from https://github.com/NeurodataWithoutBorders/matnwb/releases or from the [![View NeurodataWithoutBorders/matnwb on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://www.mathworks.com/matlabcentral/fileexchange/67741-neurodatawithoutborders-matnwb). You can also check out the latest development version via 
 
 ```bash
 git clone https://github.com/NeurodataWithoutBorders/matnwb.git
 ```
 
-#### Step 2: Download the NWB Schema
-
-Download the current release of the NWB format schema from https://github.com/NeurodataWithoutBorders/nwb-schema/releases or check out the latest development via 
-
-```bash
-git clone --recursive https://github.com/NeurodataWithoutBorders/nwb-schema.git
-```
-
-#### Step 3: Generate the API
+### Step 2: Generate the API
 
 From the Matlab command line, generate code from the copy of the NWB schema.  The command also takes variable arguments from any extensions.
 
@@ -55,7 +46,9 @@ From the Matlab command line, generate code from the copy of the NWB schema.  Th
 generateCore(); % generate core namespace located in the repository.
 ```
 
-The command also takes variable arguments from any extensions.
+### Optional: Generate MatNWB code for extensions
+
+The `generateCore` command also takes variable arguments from any extensions.
 
 ```matlab
 generateCore('schema/core/nwb.namespace.yaml', '.../my_extensions1.namespace.yaml',...);
@@ -71,6 +64,14 @@ Generated Matlab code will be put a `+types` subdirectory.  This is a Matlab pac
 
 ```matlab
 nwb=nwbRead('data.nwb');
+```
+
+### Optional: Download the NWB format schema
+
+Download the current release of the NWB format schema from https://github.com/NeurodataWithoutBorders/nwb-schema/releases or check out the latest development via 
+
+```bash
+git clone --recursive https://github.com/NeurodataWithoutBorders/nwb-schema.git
 ```
 
 ## API Documentation

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This package reads and writes NWB:N 2.0 files and does not support older formats
 
 ### Step 1: Download MatNWB
 
-Download the current release of MatNWB from https://github.com/NeurodataWithoutBorders/matnwb/releases or from the [![View NeurodataWithoutBorders/matnwb on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://www.mathworks.com/matlabcentral/fileexchange/67741-neurodatawithoutborders-matnwb). You can also check out the latest development version via 
+Download the current release of MatNWB from the [MatNWB releases page](https://github.com/NeurodataWithoutBorders/matnwb/releases) or from the [![View NeurodataWithoutBorders/matnwb on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://www.mathworks.com/matlabcentral/fileexchange/67741-neurodatawithoutborders-matnwb). You can also check out the latest development version via 
 
 ```bash
 git clone https://github.com/NeurodataWithoutBorders/matnwb.git
@@ -40,7 +40,7 @@ git clone https://github.com/NeurodataWithoutBorders/matnwb.git
 
 ### Step 2: Generate the API
 
-From the Matlab command line, generate code from the copy of the NWB schema.  The command also takes variable arguments from any extensions.
+From the Matlab command line, generate code from the copy of the NWB schema. The command also takes variable arguments from any extensions.
 
 ```matlab
 generateCore(); % generate core namespace located in the repository.
@@ -68,7 +68,7 @@ nwb=nwbRead('data.nwb');
 
 ### Optional: Download the NWB format schema
 
-Download the current release of the NWB format schema from https://github.com/NeurodataWithoutBorders/nwb-schema/releases or check out the latest development via 
+Download the current release of the NWB format schema from the [nwb-schema releases page](https://github.com/NeurodataWithoutBorders/nwb-schema/releases) or check out the latest development via 
 
 ```bash
 git clone --recursive https://github.com/NeurodataWithoutBorders/nwb-schema.git


### PR DESCRIPTION
Step 2 of the setup (Download the NWB Schema) is not necessary for nearly all users since the schema is already packaged inside MatNWB in nwb-schema. This PR makes Step 2 optional and moves it to the end of the setup instructions.