### PR TITLE
Add Nwb search method for specific types.

### DIFF
--- a/NwbFile.m
+++ b/NwbFile.m
@@ -169,6 +169,23 @@ classdef NwbFile < types.core.NWBFile
     end
 end
 
+function tf = metaHasType(mc, typeSuffix)
+assert(isa(mc, 'meta.class'));
+tf = false;
+if endsWith(mc.Name, typeSuffix, 'IgnoreCase', true)
+    tf = true;
+    return;
+end
+
+for i = 1:length(mc.SuperclassList)
+    sc = mc.SuperclassList(i);
+    if metaHasType(sc, typeSuffix)
+        tf = true;
+        return;
+    end
+end
+end
+
 function pathToObjectMap = searchProperties(...
     pathToObjectMap,...
     obj,...
@@ -191,11 +208,8 @@ end
 for i = 1:length(propertyNames)
     propName = propertyNames{i};
     propValue = getProperty(obj, propName);
-    propClass = class(propValue);
     fullPath = [basePath '/' propName];
-    if isa(propValue, typename)...
-            || strcmpi(propClass, typename)...
-            || endsWith(lower(propClass), lower(typename))
+    if metaHasType(metaclass(propValue), typename)
         pathToObjectMap(fullPath) = propValue;
     end
     

--- a/NwbFile.m
+++ b/NwbFile.m
@@ -193,7 +193,8 @@ for i = 1:length(propertyNames)
     propValue = getProperty(obj, propName);
     propClass = class(propValue);
     fullPath = [basePath '/' propName];
-    if strcmpi(propClass, typename)...
+    if isa(propValue, typename)...
+            || strcmpi(propClass, typename)...
             || endsWith(lower(propClass), lower(typename))
         pathToObjectMap(fullPath) = propValue;
     end


### PR DESCRIPTION
`nwb.searchFor(typename)` searches the nwb object recursively for any objects that satisfy any one of the following criteria:

1. object is a class/subclass of class specified by `typename` (case sensitive)
2. object's class/subclass name ends with `typename` (case insensitive)

It then returns a `containers.Map` object that consists of a `nwb.resolve()`-able class mapped to the found object.
**Note** the provided path may not be accurate to its actual HDF5 path. Its only guarantee is that the path is `resolve()`-able.