### PR TITLE
Fix for specification embedding when `namespaces` not in working directory

### DIFF
--- a/+misc/getMatnwbDir.m
+++ b/+misc/getMatnwbDir.m
@@ -1,0 +1,39 @@
+function [matnwbDir] = getMatnwbDir(varargin)
+	% Find the absolute path location of the matnwb directory.
+	% started: 2020.07.02 [11:53:52]
+	% inputs
+		%
+	% outputs
+		%
+
+	% changelog
+		% 2020.07.02 [11:53:58] - Started function, add warnings. - Biafra Ahanonu
+	% TODO
+		%
+
+	try
+		% Get the actual location of the matnwb directory. This assumes "getMatnwbDir" is within the +misc matnwb package folder.
+		fnLoc = dbstack('-completenames');
+		fnLoc = fnLoc(1).file;
+		[fnDir,~,~] = fileparts(fnLoc);
+		[matnwbDir,~,~] = fileparts(fnDir);
+
+		% Check directory exists else throw a warning letting the user know.
+		dirExists = subfxnDirCheck(matnwbDir,1);
+	catch err
+		disp(repmat('@',1,7))
+		disp(getReport(err,'extended','hyperlinks','on'));
+		disp(repmat('@',1,7))
+	end
+end
+function dirExists = subfxnDirCheck(namespaceDir,dispWarning)
+   if exist(namespaceDir,'dir')==7
+        dirExists = 1;
+        fprintf('Found "matnwb" root directory at: %s.\n',namespaceDir);
+   else
+        dirExists = 0;
+        if dispWarning==1
+            warning('Did not find "matnwb" root directory at %s. Using defaults.',namespaceDir)
+        end
+   end
+end

--- a/+misc/getNamespaceDir.m
+++ b/+misc/getNamespaceDir.m
@@ -1,0 +1,59 @@
+function [namespaceDir] = getNamespaceDir(varargin)
+    % Get the location of the namespaces directory regardless of current MATLAB working directory.
+    % started: 2020.07.02 [11:20:30]
+    % inputs
+        %
+    % outputs
+        %
+
+    % changelog
+        % 2020.07.02 [11:24:10] - Function created and added warning if namespaces directory could not be found. - Biafra Ahanonu.
+    % TODO
+        %
+
+    try
+       % Get the actual location of the matnwb directory.
+       fnDir = misc.getMatnwbDir();
+
+       % Get full path name to namespaces directory and list of files
+       namespaceDir = fullfile(fnDir, 'namespaces');
+
+       % Check directory exists else throw a warning letting the user know.
+       dirExists = subfxnDirCheck(namespaceDir,1);
+       if dirExists==0
+            namespaceDir = subfxnDefaultNamespaces();
+        elseif dirExists==1
+            % Do nothing.
+        end
+    catch err
+        % Attempt to load namespaces directory using prior methods.
+        namespaceDir = subfxnDefaultNamespaces();
+        disp(repmat('@',1,7))
+        disp(getReport(err,'extended','hyperlinks','on'));
+        disp(repmat('@',1,7))
+    end
+end
+function dirExists = subfxnDirCheck(namespaceDir,dispWarning)
+   if exist(namespaceDir,'dir')==7
+        dirExists = 1;
+        fprintf('Found "namespaces" directory at: %s.\n',namespaceDir);
+   else
+        dirExists = 0;
+        if dispWarning==1
+            warning('Directory "namespaces" not found at %s. Using defaults.',namespaceDir)
+        end
+   end
+end
+function namespaceDir = subfxnDefaultNamespaces()
+    try
+        namespaceDir = fullfile(misc.getWorkspace(), 'namespaces');
+        dirExists = subfxnDirCheck(namespaceDir,0);
+        if dirExists==0
+            namespaceDir = 'namespaces';
+            subfxnDirCheck(namespaceDir,0);
+        end
+    catch
+        namespaceDir = 'namespaces';
+        subfxnDirCheck(namespaceDir,0);
+    end
+end

--- a/+schemes/exportJson.m
+++ b/+schemes/exportJson.m
@@ -3,13 +3,8 @@ function JsonData = exportJson()
 %   returns containers.map of namespace names.
 
 % Get the actual location of the matnwb directory.
-fnLoc = dbstack('-completenames');
-fnLoc = fnLoc(1).file;
-[fnDir,~,~] = fileparts(fnLoc);
-[fnDir,~,~] = fileparts(fnDir);
+namespaceDir = misc.getNamespaceDir();
 
-% Get full path name to namespaces directory and list of files
-namespaceDir = fullfile(fnDir, 'namespaces');
 % namespaceDir = fullfile(misc.getWorkspace(), 'namespaces');
 namespaceList = dir(namespaceDir);
 isFileMask = ~[namespaceList.isdir];

--- a/+schemes/exportJson.m
+++ b/+schemes/exportJson.m
@@ -1,7 +1,16 @@
 function JsonData = exportJson()
 %TOJSON loads and converts loaded namespaces to json strings
 %   returns containers.map of namespace names.
-namespaceDir = fullfile(misc.getWorkspace(), 'namespaces');
+
+% Get the actual location of the matnwb directory.
+fnLoc = dbstack('-completenames');
+fnLoc = fnLoc(1).file;
+[fnDir,~,~] = fileparts(fnLoc);
+[fnDir,~,~] = fileparts(fnDir);
+
+% Get full path name to namespaces directory and list of files
+namespaceDir = fullfile(fnDir, 'namespaces');
+% namespaceDir = fullfile(misc.getWorkspace(), 'namespaces');
 namespaceList = dir(namespaceDir);
 isFileMask = ~[namespaceList.isdir];
 namespaceFiles = namespaceList(isFileMask);
@@ -9,7 +18,6 @@ namespaceNames = {namespaceFiles.name};
 for iFile = 1:length(namespaceNames)
     [~, namespaceNames{iFile}, ~] = fileparts(namespaceNames{iFile});
 end
-
 
 Caches = schemes.loadCache(namespaceNames{:});
 JsonData = struct(...

--- a/+schemes/loadCache.m
+++ b/+schemes/loadCache.m
@@ -2,14 +2,8 @@ function Cache = loadCache(varargin)
 %LOADCACHE Loads Raw Namespace Metadata from cached directory
 
 % Get the actual location of the matnwb directory.
-fnLoc = dbstack('-completenames');
-fnLoc = fnLoc(1).file;
-[fnDir,~,~] = fileparts(fnLoc);
-[fnDir,~,~] = fileparts(fnDir);
+namespaceDir = misc.getNamespaceDir();
 
-% Get full path name to namespaces directory
-namespaceDir = fullfile(fnDir, 'namespaces');
-% namespaceDir = 'namespaces';
 fileList = dir(namespaceDir);
 fileList = fileList(~[fileList.isdir]);
 if nargin > 0

--- a/+schemes/loadCache.m
+++ b/+schemes/loadCache.m
@@ -1,6 +1,15 @@
 function Cache = loadCache(varargin)
 %LOADCACHE Loads Raw Namespace Metadata from cached directory
-namespaceDir = 'namespaces';
+
+% Get the actual location of the matnwb directory.
+fnLoc = dbstack('-completenames');
+fnLoc = fnLoc(1).file;
+[fnDir,~,~] = fileparts(fnLoc);
+[fnDir,~,~] = fileparts(fnDir);
+
+% Get full path name to namespaces directory
+namespaceDir = fullfile(fnDir, 'namespaces');
+% namespaceDir = 'namespaces';
 fileList = dir(namespaceDir);
 fileList = fileList(~[fileList.isdir]);
 if nargin > 0


### PR DESCRIPTION
Based on discussion in https://github.com/NeurodataWithoutBorders/matnwb/issues/231. I was having inconsistent embedding of the specification when running the `ophys.m` tutorial as a test and during cell extraction in my calciumImagingAnalysis package (https://github.com/bahanonu/calciumImagingAnalysis).

It appears that matnwb including the specification depends on the `namespaces` directory being in the current working directories path, else if you run `schemes.exportJson()` with `namespaces` in another part of the path then you get an empty output and `obj.embedSpecifications` will not embed the specification.

Updated both `schemes.exportJson` and `schemes.loadCache` to find the root matnwb path and load the files in the `namespaces` directory there that are needed to embed the NWB specifications in `nwbExport` created files.

To show this works, I ran the `ophys.m` tutorial in three different conditions. 
- First, I put `namespaces` directory in the current Matlab working directory (root of calciumImagingAnalysis) then ran `nwbExport(nwb, 'ophys_tutorial.nwb');` per the tutorial. Checked using `h5disp('ophys_tutorial.nwb');` and specification was found in `/specifications`.
- Second, I removed the `namespaces` directory from the working directory and re-ran the same code as above and specification was __not__ embedded (`/specifications` empty).
- Third, I ran using the modified code in this pull request with the `namespaces` directory __not__ in the working directory then ran the code as in (1). The specification was embedded.

Likely a more robust solution that will ensure users NWB files are created with embedded specifications. An additional suggested feature would be to warn the user that the specification is not being embedded because the `namespaces` directory and caches could not be found.