### PR TITLE
Corrected typo in source code documentation

### DIFF
--- a/nwbtest.m
+++ b/nwbtest.m
@@ -21,7 +21,7 @@ function results = nwbtest(varargin)
 %   Examples:
 %
 %     % Run all tests in the MatNWB test suite.
-%     nwbtests()
+%     nwbtest()
 %
 %     % Run all unit tests in the MatNWB test suite.
 %     nwbtest('Name', 'tests.unit.*')


### PR DESCRIPTION
Calling the function `nwbtests()` would give an error - it should be `nwbtest()`