### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,5 +26,5 @@ steps:
 
   - task: RunMATLABCommand@0
     inputs:
-      command: "try, addpath(genpath(pwd)); generateCore(); nwbtest; catch err, disp(err.message); exit(1); end"
+      command: "try, addpath(genpath(pwd)); generateCore(); results = nwbtest; if isempty(results), exit(1); end; catch err, disp(err.message); exit(1); end"
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,5 +15,5 @@ steps:
       release: R2020a
   - task: RunMATLABCommand@0
     inputs:
-      command: nwbtest
+      command: "try, addpath(genpath(pwd)); generateCore(); nwbtest; catch err, fprintf('Matlab error: %%s\n', err.message); exit(1); end"
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,3 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 trigger:
 - main
 
@@ -11,8 +6,9 @@ pool:
 
 steps:
   - task: InstallMATLAB@0
-    inputs:
-      release: R2020a
+    # default to latest version of Matlab installed
+    #inputs:
+    #  release: R2020a
 
   - task: UsePythonVersion@0
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,5 +15,5 @@ steps:
       release: R2020a
   - task: RunMATLABCommand@0
     inputs:
-      command: myscript
+      command: nwbtest
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,5 +15,5 @@ steps:
       release: R2020a
   - task: RunMATLABCommand@0
     inputs:
-      command: "try, addpath(genpath(pwd)); generateCore(); nwbtest; catch err, fprintf('Matlab error: %%s\n', err.message); exit(1); end"
+      command: "try, addpath(genpath(pwd)); generateCore(); nwbtest; catch err, disp(err.message); exit(1); end"
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
-
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+  - task: InstallMATLAB@0
+    inputs:
+      release: R2020a
+  - task: RunMATLABCommand@0
+    inputs:
+      command: myscript
+  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,14 @@ steps:
   - task: InstallMATLAB@0
     inputs:
       release: R2020a
+
+  - task: UsePythonVersion@0
+
+  - script: |
+      python -m pip install --upgrade pip 
+      pip install pynwb
+    displayName: 'Install PyNWB'
+
   - task: RunMATLABCommand@0
     inputs:
       command: "try, addpath(genpath(pwd)); generateCore(); nwbtest; catch err, disp(err.message); exit(1); end"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,9 @@ steps:
       release: R2020a
 
   - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+      architecture: 'x64'
 
   - script: |
       python -m pip install --upgrade pip 


### PR DESCRIPTION
Add automated run of unit tests using Azure Pipelines. Matlab can be run only on Linux. The configuration yaml specifies the latest version of Matlab but an older version, as old as 2020a can be used.

refs: 
https://www.mathworks.com/help/matlab/matlab_prog/continuous-integration-with-matlab-on-ci-platforms.html
https://marketplace.visualstudio.com/items?itemName=MathWorks.matlab-azure-devops-extension