### PR TITLE
Update Azure Pipelines CI to upload to codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/NeurodataWithoutBorders/matnwb/4) ![Azure DevOps tests](https://img.shields.io/azure-devops/tests/NeurodataWithoutBorders/matnwb/4)
+[![codecov](https://codecov.io/gh/NeurodataWithoutBorders/matnwb/branch/master/graph/badge.svg?token=apA7F24NsO)](https://codecov.io/gh/NeurodataWithoutBorders/matnwb) ![Azure DevOps tests](https://img.shields.io/azure-devops/tests/NeurodataWithoutBorders/matnwb/4)
 # MatNWB
 
 A Matlab interface for reading and writing Neurodata Without Borders (NWB) 2.0 files.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,5 +32,9 @@ steps:
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: coverage.xml
+      
+  - script: |
+      bash <(curl -s https://codecov.io/bash)
+    displayName: 'Upload coverage to codecov'
 
   


### PR DESCRIPTION
The Azure Pipelines coverage page is OK, but codecov is a little prettier and easier to navigage. Also, PyNWB and HDMF use codecov and it is nice to have all coverage information in one place.

ref: https://github.com/NeurodataWithoutBorders/matnwb/issues/240#issuecomment-760634960