### PR TITLE
Resolve BoundPipe usability issues

### DIFF
--- a/+tests/+unit/dataPipeTest.m
+++ b/+tests/+unit/dataPipeTest.m
@@ -41,16 +41,9 @@ for i = 1:totalLength
 end
 
 %% verify data
-fid = H5F.open(filename);
-did = H5D.open(fid, name);
-
-readData = H5D.read(did);
-
+readData = Pipe.load();
 testCase.verifyEqual(readData(:,:,1:10), initialData);
 testCase.verifyEqual(readData(:,:,11:end), appendData);
-
-H5D.close(did);
-H5F.close(fid);
 end
 
 function data = createData(dataType, size)

--- a/+types/+untyped/+datapipe/BoundPipe.m
+++ b/+types/+untyped/+datapipe/BoundPipe.m
@@ -232,5 +232,9 @@ classdef BoundPipe < types.untyped.datapipe.Pipe
         function obj = write(obj, ~, ~)
             return;
         end
+        
+        function data = load(obj, varargin)
+            data = obj.stub.load(varargin{:});
+        end
     end
 end


### PR DESCRIPTION
Used by external scripts and getRow()