### PR TITLE
remove positive number validation for getRow ind.

### DIFF
--- a/+tests/+system/DynamicTableTest.m
+++ b/+tests/+system/DynamicTableTest.m
@@ -148,6 +148,20 @@ classdef DynamicTableTest < tests.system.RoundTripTest & tests.system.AmendTest
     end
 
     methods (Test)
+        function getNegativeIdTest(testCase)
+            vector = types.hdmf_common.VectorData('description', 'data column', 'data', (1:10) .');
+            ids = types.hdmf_common.ElementIdentifiers('data', ((-9):0) .');
+            testtable = types.hdmf_common.DynamicTable( ...
+                'description', 'test table with DynamicTableRegion', ...
+                'colnames', {'vec'}, ...
+                'vec', vector, ...
+                'id', ids ...
+                );
+            for i = 1:length(vector.data)
+                testCase.verifyEqual(testtable.getRow(i), testtable.getRow(ids.data(i), 'useId', true));
+            end
+        end
+
         function getRowTest(testCase)
             Table = testCase.file.intervals_trials;
 

--- a/+types/+util/+dynamictable/getRow.m
+++ b/+types/+util/+dynamictable/getRow.m
@@ -10,7 +10,7 @@ function subTable = getRow(DynamicTable, ind, varargin)
 
 validateattributes(DynamicTable,...
     {'types.core.DynamicTable', 'types.hdmf_common.DynamicTable'}, {'scalar'});
-validateattributes(ind, {'numeric'}, {'positive', 'vector'});
+validateattributes(ind, {'numeric'}, {'vector'});
 
 p = inputParser;
 addParameter(p, 'columns', DynamicTable.colnames, @(x)iscellstr(x));

--- a/+types/+util/+dynamictable/getRow.m
+++ b/+types/+util/+dynamictable/getRow.m
@@ -27,6 +27,8 @@ end
 
 if p.Results.useId
     ind = getIndById(DynamicTable, ind);
+else
+    validateattributes(ind, {'numeric'}, {'positive', 'vector'});
 end
 
 for i = 1:length(columns)


### PR DESCRIPTION
fix #310, #573

If useID is True, then ind can be of value 0