### PR TITLE
updated types.util.dynamictable.getIndex to properly find VectorIndex target

### DIFF
--- a/+types/+util/+dynamictable/getIndex.m
+++ b/+types/+util/+dynamictable/getIndex.m
@@ -63,7 +63,7 @@ if VectorIndex.target.has_path()
 elseif isprop(DynamicTable, column)
     tf = VectorIndex.target == DynamicTable.(column);
 else
-    tf = VectorIndex.target == DynamicTable.vectordata.get(column);
+    tf = VectorIndex.target.target == DynamicTable.vectordata.get(column);
 end
 end
 


### PR DESCRIPTION
resolves #322 

tracked down bug to the following line of code in types.util.dynamictable.getIndex.m
```matlab
tf = VectorIndex.target== DynamicTable.vectordata.get(column);
```
modified it to the following so that the proper properties are compared.
```matlab
tf = VectorIndex.target.target== DynamicTable.vectordata.get(column);
```
Adding the extra .target allows access to the relevant field in the ObjectView object