### PR TITLE
modification to types.util.checkDtype  to keep cast integer type

### DIFF
--- a/+types/+util/checkDtype.m
+++ b/+types/+util/checkDtype.m
@@ -108,7 +108,10 @@ else
                     name, type, class(val));
             end
         else
-            val = types.util.correctType(val, type);
+            if isa(val,'double')
+                % correct type if array is double
+                val = types.util.correctType(val, type);
+            end
         end
     elseif strcmp(type, 'isodatetime')
         assert(ischar(val)...

--- a/+types/+util/checkDtype.m
+++ b/+types/+util/checkDtype.m
@@ -108,8 +108,8 @@ else
                     name, type, class(val));
             end
         else
-            if isa(val,'double')
-                % correct type if array is double
+            if ~any(strcmpi(class(val), {'int8' 'int16' 'int32' 'int64'}))
+                % correct type if integer byte size not specified
                 val = types.util.correctType(val, type);
             end
         end

--- a/+types/+util/checkDtype.m
+++ b/+types/+util/checkDtype.m
@@ -108,10 +108,7 @@ else
                     name, type, class(val));
             end
         else
-            if ~any(strcmpi(class(val), {'int8' 'int16' 'int32' 'int64'}))
-                % correct type if integer byte size not specified
-                val = types.util.correctType(val, type);
-            end
+            val = types.util.correctType(val, type);
         end
     elseif strcmp(type, 'isodatetime')
         assert(ischar(val)...

--- a/+types/+util/correctType.m
+++ b/+types/+util/correctType.m
@@ -5,6 +5,8 @@ function val = correctType(val, type)
 
 %check different types and correct
 
+class_val = class(val); %store initial class
+
 if any(strcmp(type, {'logical', 'bool'}))
     assert(islogical(val) || isnumeric(val),...
         'NWB:CorrectType:NonLogical',...
@@ -63,13 +65,15 @@ assert(startsWith(class(val), prefix),...
 
 classMatch = regexp(class(val), 'u?int(\d+)', 'once', 'tokens');
 classSize = str2double(classMatch{1});
-
-intSizeScale = [8 16 32 64];
-for iSize = find(minSize == intSizeScale, 1):find(classSize == intSizeScale, 1)
-    sizeType = sprintf('%s%d', prefix, intSizeScale(iSize));
-    if all(minVal >= double(intmin(sizeType))) && all(maxVal <= double(intmax(sizeType)))
-        val = cast(val, sizeType);
-        break;
+if ~any(strcmpi(class_val, {'int8' 'int16' 'int32' 'int64'}))
+    % correct type if integer byte size not specified
+    intSizeScale = [8 16 32 64];
+    for iSize = find(minSize == intSizeScale, 1):find(classSize == intSizeScale, 1)
+        sizeType = sprintf('%s%d', prefix, intSizeScale(iSize));
+        if all(minVal >= double(intmin(sizeType))) && all(maxVal <= double(intmax(sizeType)))
+            val = cast(val, sizeType);
+            break;
+        end
     end
 end
 end


### PR DESCRIPTION
Currently, types.util.checkDtype calls types.util.correctType function when any array is passed in with `value = 'int'`. In the case when the user has cast the array to a specific integer precision type (e.g., int16), we want to respect the class of the array. 
This PR achieves this by skipping over the call to types.util.correctType when the array integer byte size is already specified (i.e., when it's of type int8, int16, int32, or int64).

fix #339 