### PR TITLE
modification of namespace caching to exclude neurodata_types 

### DIFF
--- a/+schemes/exportJson.m
+++ b/+schemes/exportJson.m
@@ -19,7 +19,8 @@ JsonData = struct(...
 for iCache = 1:length(Caches)
     Cache = Caches(iCache);
     keepRelevantNamespace(Cache);
-    removeEmptySchemaComponents(Cache)
+    removeEmptySchemaComponents(Cache);
+    removeNeuroData_Types(Cache)
     stripNamespaceFileExt(Cache.namespace);
     JsonMap = containers.Map({'namespace'}, {jsonencode(Cache.namespace, 'ConvertInfAndNaN', true)});
     for iScheme = 1:length(Cache.filenames)
@@ -32,6 +33,16 @@ for iCache = 1:length(Caches)
     JsonData(iCache).json = JsonMap;
 end
 end
+function removeNeuroData_Types(Cache)
+    namespaces = Cache.namespace('namespaces');
+    nsSchema = namespaces{1}('schema');
+    if any(strcmpi(keys(nsSchema{1}),'neurodata_types'))
+        remove(nsSchema{1},'neurodata_types');
+    end
+    namespaces{1}('schema') = nsSchema;
+    Cache.namespace('namespaces') = namespaces;
+end
+
 function removeEmptySchemaComponents(Cache)
     Schema = Cache.schema;
     SchemaKeys = keys(Schema);


### PR DESCRIPTION
Fixes #351 
Currently, matnwb caches neurodata_types in the namespace of NWB extensions. This differs from the behavior of pynwb, which leads to the file from failing validation.

This PR modifies +schemes/exportJson.m to exclude caching of 'neurodata_types' field from namespace. See issue #351 for further details.

With this modification matnwb-generated files with NWB extension in namespace pass verification:
```bash
$ python -m pynwb.validate ndx-ecog_file_test_matnwb.nwb 
Validating ndx-ecog_file_test_matnwb.nwb against cached namespace information using namespace 'ndx-ecog'.
 - no errors found.

```