### PR TITLE
Fix nwbToTable when the Dynamic Table is empty

### DIFF
--- a/+types/+util/+dynamictable/nwbToTable.m
+++ b/+types/+util/+dynamictable/nwbToTable.m
@@ -31,6 +31,12 @@ validateattributes(DynamicTable,...
 if nargin < 2
     index = true;
 end
+
+if isempty(DynamicTable.id)
+    matlabTable = table({}, 'VariableNames', [{'id'} DynamicTable.colnames]);
+    return;
+end
+
 % initialize table with id column
 if isa(DynamicTable.id.data, 'types.untyped.DataStub')...
         || isa(DynamicTable.id.data, 'types.untyped.DataPipe')
@@ -41,11 +47,12 @@ end
 matlabTable = table( ...
     ids, ...
     'VariableNames', {'id'} ...
-);      
+);
+
 % deal with DynamicTableRegion columns when index is false
 columns = DynamicTable.colnames;
 i = 1;
-while i <length(columns)
+while i < length(columns)
     cn = DynamicTable.colnames{i};
     if isprop(DynamicTable, cn)
         cv = DynamicTable.(cn);


### PR DESCRIPTION
## Motivation

Issues found in #418

## How to test the behavior?
```MATLAB
my_table = types.hdmf_common.DynamicTable;
my_table.toTable()
```
Should not throw an error and should provide an empty table instead.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
