### PR TITLE
narrow the definition of a scalar dataset

### DIFF
--- a/+file/isShapeScalar.m
+++ b/+file/isShapeScalar.m
@@ -9,7 +9,7 @@ end
 
 isScalar = true(size(shape));
 for iOption = 1:length(shape)
-    isScalar(iOption) = any(1 ~= shape{iOption});
+    isScalar(iOption) = all(1 == shape{iOption});
 end
 end
 


### PR DESCRIPTION
Fixes #430 

## How to test the behavior?

Export the following timeseries:
```
ts = types.core.TimeSeries( ...
            'data', 12.3, ...
            'description', 'XYZ', ...
            'data_unit', 'time', ...
            'timestamps', 12.3);
```
However you validate it, the space must be using a non-scalar space specification.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
