### PR TITLE
Set H5S_NULL if the data is not chunked and is empty.

### DIFF
--- a/+io/mapData2H5.m
+++ b/+io/mapData2H5.m
@@ -30,8 +30,10 @@ if ischar(data)
     end
 elseif ~forceArray && ~iscell(data) && isscalar(data)
     sid = H5S.create('H5S_SCALAR');
+elseif ~forceChunked && isempty(data)
+    sid = H5S.create('H5S_NULL');
 else
-    if isvector(data)
+    if isvector(data) || isempty(data)
         num_dims = 1;
         dims = length(data);
     else


### PR DESCRIPTION
## Motivation

While investigating #434 it seems that `colnames` is not writable if it is empty. This is technically allowable given the schema simply listing its shape as one-dimensional with no bounds. However, calling `io.writeAttribute` appears to result in an unknown HDF5 error, perhaps because the dimensions are set to zero.

The solution right now is something like https://github.com/h5py/h5py/issues/279 when the dataset is actually empty. Not sure how this would need to work for chunked datasets as these can be amended.

## How to test the behavior?

Running the example in this comment should work:
https://github.com/NeurodataWithoutBorders/matnwb/issues/434#issuecomment-1150081458

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
