### PR TITLE
disable echo on tutorial tests

### DIFF
--- a/+tests/+unit/tutorialTest.m
+++ b/+tests/+unit/tutorialTest.m
@@ -8,12 +8,17 @@ testCase.applyFixture(matlab.unittest.fixtures.PathFixture(rootPath));
 tutorialPath = fullfile(rootPath, 'tutorials');
 addpath(tutorialPath);
 testCase.TestData.listing = dir(tutorialPath);
+echo('off');
 end
 
 function setup(testCase)
 testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
 generateCore('savedir', '.');
 rehash();
+end
+
+function teardownOnce(testCase)
+echo('on');
 end
 
 function testTutorials(testCase)

--- a/+tests/+unit/tutorialTest.m
+++ b/+tests/+unit/tutorialTest.m
@@ -8,16 +8,16 @@ testCase.applyFixture(matlab.unittest.fixtures.PathFixture(rootPath));
 tutorialPath = fullfile(rootPath, 'tutorials');
 addpath(tutorialPath);
 testCase.TestData.listing = dir(tutorialPath);
-echo('off');
 end
 
 function setup(testCase)
 testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
 generateCore('savedir', '.');
 rehash();
+echo('off');
 end
 
-function teardownOnce(testCase)
+function teardown(testCase)
 echo('on');
 end
 


### PR DESCRIPTION
## Motivation

Debugging the CI logs are very annoying without this.

## How to test the behavior?
```MATLAB
nwbtest('Name', 'tests.unit.tutorialTest');
```
Should only output test suit printouts.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
