### PR TITLE
Add check for non-cellstr cell types

### DIFF
--- a/+io/mapData2H5.m
+++ b/+io/mapData2H5.m
@@ -6,6 +6,11 @@ function [tid, sid, data] = mapData2H5(fid, data, varargin)
 forceArray = any(strcmp('forceArray', varargin));
 forceChunked = any(strcmp('forceChunking', varargin));
 
+if iscell(data)
+    assert(iscellstr(data), 'NWB:MapData:NonCellStr', ['Cell arrays must be ' ...
+        'cell arrays of character vectors. Cell arrays of other types are ' ...
+        'not supported.']);
+end
 tid = io.getBaseType(class(data));
 
 % max size is always unlimited


### PR DESCRIPTION
## Motivation

One potential misconception about ragged array before may cause a type corruption on write. In the case of #462, `addRow` supports multi-ragged array appending behavior via use of cell arrays. This is **not true** for regular instantiation. Regular constructor instantiation is intended for purely raw data initialization.

Users who wish to emulate the behavior in `addRow` should actually construct the vector index objects themselves if they wish to construct dyamic tables using the default constructor.

In the case of MatNWB, cell arrays passed in this way **must** error, otherwise silent data corruption can occur.

## How to test the behavior?
```MATLAB
metadataBlocks = mat2cell(rand(10,13), zeros(1, 5) + 2, ones(1, 13));
metadata = cell(1,13);
for iColumn = 1:13
    metadata{iColumn} = metadataBlocks(:,iColumn);
end
metadata = table(metadata{:});

dt = types.hdmf_common.DynamicTable( ...
    'colnames', {'cluster_id','local_cluster_id','type',...
    'peak_channel_index','peak_channel_id',... % Provide the column order. All column names have to be defined below
    'local_peak_channel_id','rel_horz_pos','rel_vert_pos',...
    'isi_violations','isolation_distance','area','probe_id',...
    'spike_times','spike_times_index'}, ...
    'description', 'Units table', ...
    'id', types.hdmf_common.ElementIdentifiers( ...
    'data', 0:(height(metadata) - 1)), ...
    'cluster_id', types.hdmf_common.VectorData( ...
    'data', metadata{:,1}, ...
    'description', 'Unique cluster id'), ...
    'local_cluster_id', types.hdmf_common.VectorData( ...
    'data', metadata{:,2}, ...
    'description', 'Local cluster id on the probe'), ...
    'type', types.hdmf_common.VectorData( ...
    'data', metadata{:,3}, ...
    'description', 'Cluster type: unit vs mua'), ...
    'peak_channel_index', types.hdmf_common.VectorData( ...
    'data', metadata{:,4}, ...
    'description', 'Peak channel row index in the electrode table'), ...
    'peak_channel_id', types.hdmf_common.VectorData( ...
    'data', metadata{:,5}, ...
    'description', 'Unique ID of the channel with the largest cluster waveform amplitude'), ...
    'local_peak_channel_id', types.hdmf_common.VectorData( ...
    'data', metadata{:,6}, ...
    'description', 'Local probe channel with the largest cluster waveform amplitude'), ...
    'rel_horz_pos', types.hdmf_common.VectorData( ...
    'data', metadata{:,7}, ...
    'description', 'Probe-relative horizontal position in mm'), ...
    'rel_vert_pos', types.hdmf_common.VectorData( ...
    'data', metadata{:,8}, ...
    'description', 'Probe tip-relative vertical position in mm'), ...
    'isi_violations', types.hdmf_common.VectorData( ...
    'data', metadata{:,9}, ...
    'description', 'Interstimulus interval violations (unit quality measure)'), ...
    'isolation_distance', types.hdmf_common.VectorData( ...
    'data', metadata{:,10}, ...
    'description', 'Cluster isolation distance (unit quality measure)'), ...
    'area', types.hdmf_common.VectorData( ...
    'data', metadata{:,11}, ...
    'description', ['Brain area where the unit is located. Internal thalamic' ...
    'nuclei divisions are not precise, because they are derived from unit locations on the probe.']), ...
    'probe_id', types.hdmf_common.VectorData( ...
    'data', metadata{:,12}, ...
    'description', 'Probe id where the unit is located'), ...
    'electrode_group', types.hdmf_common.VectorData( ...
    'data', metadata{:,13}, ...
    'description', 'Recording channel groups'));

fid = H5F.create('test.h5');
refs = dt.export(fid, '/', {});
H5F.close(fid);
```

Should throw an error. Not write the file.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
