### PR TITLE
Allow string inputs for most interfaces

### DIFF
--- a/+types/+untyped/DataStub.m
+++ b/+types/+untyped/DataStub.m
@@ -16,8 +16,12 @@ classdef (Sealed) DataStub < handle
     
     methods
         function obj = DataStub(filename, path)
-            obj.filename = filename;
-            obj.path = path;
+            validateattributes(filename, {'char', 'string'}, {'scalartext'} ...
+                , 'types.untyped.DataStub', 'filename', 1);
+            validateattributes(path, {'char', 'string'}, {'scalartext'} ...
+                , 'types.untyped.DataStub', 'path', 2);
+            obj.filename = char(filename);
+            obj.path = char(path);
         end
         
         function sid = get_space(obj)

--- a/+types/+untyped/ExternalLink.m
+++ b/+types/+untyped/ExternalLink.m
@@ -6,8 +6,12 @@ classdef ExternalLink < handle
     
     methods
         function obj = ExternalLink(filename, path)
-            obj.filename = filename;
-            obj.path = path;
+            validateattributes(filename, {'char', 'string'}, {'scalartext'} ...
+                , 'types.untyped.ExternalLink', 'filename', 1);
+            validateattributes(path, {'char', 'string'}, {'scalartext'} ...
+                , 'types.untyped.ExternalLink', 'path', 2);
+            obj.filename = char(filename);
+            obj.path = char(path);
         end
         
         function data = deref(obj)

--- a/+types/+untyped/ObjectView.m
+++ b/+types/+untyped/ObjectView.m
@@ -23,10 +23,12 @@ classdef ObjectView < handle
             % target = A generated NWB object.
             
             if ischar(target) || isstring(target)
-                validateattributes(target, {'char', 'string'}, {'scalartext'});
-                obj.path = target;
+                validateattributes(target, {'char', 'string'}, {'scalartext'} ...
+                    , 'types.untyped.ObjectView', 'target string', 1);
+                obj.path = char(target);
             else
-                validateattributes(target, {'types.untyped.MetaClass'}, {'scalar'});
+                validateattributes(target, {'types.untyped.MetaClass'}, {'scalar'} ...
+                    , 'types.untyped.ObjectView', 'target object', 1);
                 obj.target = target;
             end
         end

--- a/+types/+untyped/SoftLink.m
+++ b/+types/+untyped/SoftLink.m
@@ -18,16 +18,19 @@ classdef SoftLink < handle
             % target = pre-generated NWB object.
             
             if ischar(target) || isstring(target)
-                validateattributes(target, {'char', 'string'}, {'scalartext'});
-                obj.path = target;
+                validateattributes(target, {'char', 'string'}, {'scalartext'} ...
+                    , 'types.untyped.SoftLink', 'target string', 1);
+                obj.path = char(target);
             else
-                validateattributes(target, {'types.untyped.MetaClass'}, {'scalar'});
+                validateattributes(target, {'types.untyped.MetaClass'}, {'scalar'} ...
+                    , 'types.untyped.SoftLink', 'target object', 2);
                 obj.target = target;
             end
         end
         
         function set.path(obj, val)
-            validateattributes(val, {'char', 'string'}, {'scalartext'});
+            validateattributes(val, {'char', 'string'}, {'scalartext'} ...
+                , '(types.untyped.SoftLink).path', 'path', 2);
             obj.path = val;
         end
         

--- a/generateCore.m
+++ b/generateCore.m
@@ -1,55 +1,55 @@
 function generateCore(varargin)
-% GENERATECORE Generate Matlab classes from NWB core schema files
-%   GENERATECORE()  Generate classes (Matlab m-files) from the
-%   NWB:N core namespace file. By default, generates off of the most recent nwb-schema
-%   release.
-%
-%   GENERATECORE(version)  Generate classes for the
-%   core namespace of the listed version.
-%
-%   A cache of schema data is generated in the 'namespaces' subdirectory in
-%   the current working directory.  This is for allowing cross-referencing
-%   classes between multiple namespaces.
-%
-%   Output files are generated placed in a '+types' subdirectory in the
-%   current working directory.
-%   
-%   GENERATECORE(__, 'savedir', saveDirectory) Generates the core class
-%   files in the specified directory.
-%
-%   Example:
-%      generateCore();
-%      generateCore('2.2.3');
-%
-%   See also GENERATEEXTENSION
-
-latestVersion = '2.6.0';
-
-if nargin == 0 || strcmp(varargin{1}, 'savedir')
-    version = latestVersion;
-else
-    version = varargin{1};
-    validateattributes(version, {'char', 'string'}, {'scalartext'}, 'generateCore', 'version', 1);
-    version = char(version);
-    varargin = varargin(2:end);
-end
-
-if strcmp(version, 'latest')
-    version = latestVersion;
-end
-
-schemaPath = fullfile(misc.getMatnwbDir(), 'nwb-schema', version);
-corePath = fullfile(schemaPath, 'core', 'nwb.namespace.yaml');
-commonPath = fullfile(schemaPath,...
-    'hdmf-common-schema', ...
-    'common',...
-    'namespace.yaml');
-assert(2 == exist(corePath, 'file'),...
-    'NWB:GenerateCore:MissingCoreSchema',...
-    'Cannot find suitable core namespace for schema version `%s`',...
-    version);
-if 2 == exist(commonPath, 'file')
-    generateExtension(commonPath, varargin{:});
-end
-generateExtension(corePath, varargin{:});
+    % GENERATECORE Generate Matlab classes from NWB core schema files
+    %   GENERATECORE()  Generate classes (Matlab m-files) from the
+    %   NWB:N core namespace file. By default, generates off of the most recent nwb-schema
+    %   release.
+    %
+    %   GENERATECORE(version)  Generate classes for the
+    %   core namespace of the listed version.
+    %
+    %   A cache of schema data is generated in the 'namespaces' subdirectory in
+    %   the current working directory.  This is for allowing cross-referencing
+    %   classes between multiple namespaces.
+    %
+    %   Output files are generated placed in a '+types' subdirectory in the
+    %   current working directory.
+    %
+    %   GENERATECORE(__, 'savedir', saveDirectory) Generates the core class
+    %   files in the specified directory.
+    %
+    %   Example:
+    %      generateCore();
+    %      generateCore('2.2.3');
+    %
+    %   See also GENERATEEXTENSION
+    
+    latestVersion = '2.6.0';
+    
+    if nargin == 0 || strcmp(varargin{1}, 'savedir')
+        version = latestVersion;
+    else
+        version = varargin{1};
+        validateattributes(version, {'char', 'string'}, {'scalartext'}, 'generateCore', 'version', 1);
+        version = char(version);
+        varargin = varargin(2:end);
+    end
+    
+    if strcmp(version, 'latest')
+        version = latestVersion;
+    end
+    
+    schemaPath = fullfile(misc.getMatnwbDir(), 'nwb-schema', version);
+    corePath = fullfile(schemaPath, 'core', 'nwb.namespace.yaml');
+    commonPath = fullfile(schemaPath,...
+        'hdmf-common-schema', ...
+        'common',...
+        'namespace.yaml');
+    assert(2 == exist(corePath, 'file'),...
+        'NWB:GenerateCore:MissingCoreSchema',...
+        'Cannot find suitable core namespace for schema version `%s`',...
+        version);
+    if 2 == exist(commonPath, 'file')
+        generateExtension(commonPath, varargin{:});
+    end
+    generateExtension(corePath, varargin{:});
 end

--- a/generateCore.m
+++ b/generateCore.m
@@ -29,8 +29,9 @@ if nargin == 0 || strcmp(varargin{1}, 'savedir')
     version = latestVersion;
 else
     version = varargin{1};
+    validateattributes(version, {'char', 'string'}, {'scalartext'}, 'generateCore', 'version', 1);
+    version = char(version);
     varargin = varargin(2:end);
-    validateattributes(version, {'char'}, {'scalartext'});
 end
 
 if strcmp(version, 'latest')

--- a/generateExtension.m
+++ b/generateExtension.m
@@ -16,9 +16,15 @@ function generateExtension(varargin)
 %      generateExtension('schema\myext\myextension.namespace.yaml', 'schema\myext2\myext2.namespace.yaml');
 %
 %   See also GENERATECORE
-assert(iscellstr(varargin),...
-    'NWB:GenerateExtension:InvalidArguments',...
-    'Must be a cell array of strings.'); %#ok<ISCLSTR>
+
+for iOption = 1:length(varargin)
+    option = varargin{iOption};
+    validateattributes(option, {'char', 'string'}, {'scalartext'} ...
+        , 'generateExtension', 'extension name', iOption);
+    if isstring(option)
+        varargin{iOption} = char(option);
+    end
+end
 
 saveDirMask = strcmp(varargin, 'savedir');
 if any(saveDirMask)

--- a/generateExtension.m
+++ b/generateExtension.m
@@ -1,62 +1,62 @@
 function generateExtension(varargin)
-% GENERATEEXTENSION Generate Matlab classes from NWB extension schema file
-%   GENERATEEXTENSION(extension_path...)  Generate classes
-%   (Matlab m-files) from one or more NWB:N schema extension namespace
-%   files.  A registry of already generated core types is used to resolve
-%   dependent types.
-%
-%   A cache of schema data is generated in the 'namespaces' subdirectory in
-%   the current working directory.  This is for allowing cross-referencing
-%   classes between multiple namespaces.
-%
-%   Output files are generated placed in a '+types' subdirectory in the
-%   current working directory.
-%
-%   Example:
-%      generateExtension('schema\myext\myextension.namespace.yaml', 'schema\myext2\myext2.namespace.yaml');
-%
-%   See also GENERATECORE
-
-for iOption = 1:length(varargin)
-    option = varargin{iOption};
-    validateattributes(option, {'char', 'string'}, {'scalartext'} ...
-        , 'generateExtension', 'extension name', iOption);
-    if isstring(option)
-        varargin{iOption} = char(option);
-    end
-end
-
-saveDirMask = strcmp(varargin, 'savedir');
-if any(saveDirMask)
-    assert(~saveDirMask(end),...
-        'NWB:GenerateExtenion:InvalidParameter',...
-        'savedir must be paired with the desired save directory.');
-    saveDir = varargin{find(saveDirMask, 1, 'last') + 1};
-    saveDirParametersMask = saveDirMask | circshift(saveDirMask, 1);
-    sourceList = varargin(~saveDirParametersMask);
-else
-    saveDir = misc.getMatnwbDir();
-    sourceList = varargin;
-end
-
-for iNamespaceFiles = 1:length(sourceList)
-    source = sourceList{iNamespaceFiles};
-    validateattributes(source, {'char', 'string'}, {'scalartext'});
+    % GENERATEEXTENSION Generate Matlab classes from NWB extension schema file
+    %   GENERATEEXTENSION(extension_path...)  Generate classes
+    %   (Matlab m-files) from one or more NWB:N schema extension namespace
+    %   files.  A registry of already generated core types is used to resolve
+    %   dependent types.
+    %
+    %   A cache of schema data is generated in the 'namespaces' subdirectory in
+    %   the current working directory.  This is for allowing cross-referencing
+    %   classes between multiple namespaces.
+    %
+    %   Output files are generated placed in a '+types' subdirectory in the
+    %   current working directory.
+    %
+    %   Example:
+    %      generateExtension('schema\myext\myextension.namespace.yaml', 'schema\myext2\myext2.namespace.yaml');
+    %
+    %   See also GENERATECORE
     
-    [localpath, ~, ~] = fileparts(source);
-    assert(2 == exist(source, 'file'),...
-        'NWB:GenerateExtension:FileNotFound', 'Path to file `%s` could not be found.', source);
-    fid = fopen(source);
-    namespaceText = fread(fid, '*char') .';
-    fclose(fid);
-    
-    Namespaces = spec.generate(namespaceText, localpath);
-
-    for iNamespace = 1:length(Namespaces)
-        Namespace = Namespaces(iNamespace);
-        spec.saveCache(Namespace, saveDir);
-        file.writeNamespace(Namespace.name, saveDir);
-        rehash();
+    for iOption = 1:length(varargin)
+        option = varargin{iOption};
+        validateattributes(option, {'char', 'string'}, {'scalartext'} ...
+            , 'generateExtension', 'extension name', iOption);
+        if isstring(option)
+            varargin{iOption} = char(option);
+        end
     end
-end
+    
+    saveDirMask = strcmp(varargin, 'savedir');
+    if any(saveDirMask)
+        assert(~saveDirMask(end),...
+            'NWB:GenerateExtenion:InvalidParameter',...
+            'savedir must be paired with the desired save directory.');
+        saveDir = varargin{find(saveDirMask, 1, 'last') + 1};
+        saveDirParametersMask = saveDirMask | circshift(saveDirMask, 1);
+        sourceList = varargin(~saveDirParametersMask);
+    else
+        saveDir = misc.getMatnwbDir();
+        sourceList = varargin;
+    end
+    
+    for iNamespaceFiles = 1:length(sourceList)
+        source = sourceList{iNamespaceFiles};
+        validateattributes(source, {'char', 'string'}, {'scalartext'});
+        
+        [localpath, ~, ~] = fileparts(source);
+        assert(2 == exist(source, 'file'),...
+            'NWB:GenerateExtension:FileNotFound', 'Path to file `%s` could not be found.', source);
+        fid = fopen(source);
+        namespaceText = fread(fid, '*char') .';
+        fclose(fid);
+        
+        Namespaces = spec.generate(namespaceText, localpath);
+        
+        for iNamespace = 1:length(Namespaces)
+            Namespace = Namespaces(iNamespace);
+            spec.saveCache(Namespace, saveDir);
+            file.writeNamespace(Namespace.name, saveDir);
+            rehash();
+        end
+    end
 end

--- a/nwbExport.m
+++ b/nwbExport.m
@@ -1,44 +1,44 @@
 function nwbExport(nwb, filenames)
-%NWBEXPORT Writes an NWB file.
-%  nwbRead(nwb,filename) Writes the nwb object to a file at filename.
-%
-%  Example:
-%    % Generate Matlab code for the NWB objects from the core schema.
-%    % This only needs to be done once.
-%    generateCore('schema\core\nwb.namespace.yaml');
-%    % Create some fake fata and write
-%    nwb = NwbFile;
-%    nwb.session_start_time = datetime('now');
-%    nwb.identifier = 'EMPTY';
-%    nwb.session_description = 'empty test file';
-%    nwbExport(nwb, 'empty.nwb');
-%
-%  See also GENERATECORE, GENERATEEXTENSION, NWBFILE, NWBREAD
-validateattributes(nwb, {'NwbFile'}, {'nonempty'}, 'nwbExport', 'nwb', 1);
-validateattributes(filenames, {'cell', 'string', 'char'}, {'nonempty'}, 'nwbExport', 'filenames', 2);
-if isstring(filenames)
-    filenames = convertStringsToChars(filenames);
-end
-if iscell(filenames)
-    for iName = 1:length(filenames)
-        name = filenames{iName};
-        validateattributes(name, {'string', 'char'}, {'scalartext', 'nonempty'} ...
-            , 'nwbExport', 'filenames', 2);
-        filenames{iName} = char(name);
+    %NWBEXPORT Writes an NWB file.
+    %  nwbRead(nwb,filename) Writes the nwb object to a file at filename.
+    %
+    %  Example:
+    %    % Generate Matlab code for the NWB objects from the core schema.
+    %    % This only needs to be done once.
+    %    generateCore('schema\core\nwb.namespace.yaml');
+    %    % Create some fake fata and write
+    %    nwb = NwbFile;
+    %    nwb.session_start_time = datetime('now');
+    %    nwb.identifier = 'EMPTY';
+    %    nwb.session_description = 'empty test file';
+    %    nwbExport(nwb, 'empty.nwb');
+    %
+    %  See also GENERATECORE, GENERATEEXTENSION, NWBFILE, NWBREAD
+    validateattributes(nwb, {'NwbFile'}, {'nonempty'}, 'nwbExport', 'nwb', 1);
+    validateattributes(filenames, {'cell', 'string', 'char'}, {'nonempty'}, 'nwbExport', 'filenames', 2);
+    if isstring(filenames)
+        filenames = convertStringsToChars(filenames);
     end
-end
-if ~isscalar(nwb)
-    assert(~ischar(filenames) && length(filenames) == length(nwb), ...
-        'NwbFile and filename array dimensions must match.');
-end
-
-for iFiles = 1:length(nwb)
-    if iscellstr(filenames)
-        filename = filenames{iFiles};
-    else
-        filename = filenames;
+    if iscell(filenames)
+        for iName = 1:length(filenames)
+            name = filenames{iName};
+            validateattributes(name, {'string', 'char'}, {'scalartext', 'nonempty'} ...
+                , 'nwbExport', 'filenames', 2);
+            filenames{iName} = char(name);
+        end
+    end
+    if ~isscalar(nwb)
+        assert(~ischar(filenames) && length(filenames) == length(nwb), ...
+            'NwbFile and filename array dimensions must match.');
     end
     
-    nwb(iFiles).export(filename);
-end
+    for iFiles = 1:length(nwb)
+        if iscellstr(filenames)
+            filename = filenames{iFiles};
+        else
+            filename = filenames;
+        end
+        
+        nwb(iFiles).export(filename);
+    end
 end

--- a/nwbExport.m
+++ b/nwbExport.m
@@ -14,25 +14,31 @@ function nwbExport(nwb, filenames)
 %    nwbExport(nwb, 'empty.nwb');
 %
 %  See also GENERATECORE, GENERATEEXTENSION, NWBFILE, NWBREAD
-validateattributes(nwb, {'NwbFile'}, {'nonempty'});
-validateattributes(filenames, {'cell', 'string', 'char'}, {'nonempty'});
+validateattributes(nwb, {'NwbFile'}, {'nonempty'}, 'nwbExport', 'nwb', 1);
+validateattributes(filenames, {'cell', 'string', 'char'}, {'nonempty'}, 'nwbExport', 'filenames', 2);
+if isstring(filenames)
+    filenames = convertStringsToChars(filenames);
+end
 if iscell(filenames)
-    assert(iscellstr(filenames), 'filename cell array must consist of strings');
+    for iName = 1:length(filenames)
+        name = filenames{iName};
+        validateattributes(name, {'string', 'char'}, {'scalartext', 'nonempty'} ...
+            , 'nwbExport', 'filenames', 2);
+        filenames{iName} = char(name);
+    end
 end
 if ~isscalar(nwb)
     assert(~ischar(filenames) && length(filenames) == length(nwb), ...
         'NwbFile and filename array dimensions must match.');
 end
 
-for i=1:length(nwb)
+for iFiles = 1:length(nwb)
     if iscellstr(filenames)
-        filename = filenames{i};
-    elseif isstring(filenames)
-        filename = filenames(i);
+        filename = filenames{iFiles};
     else
         filename = filenames;
     end
     
-    nwb(i).export(filename);
+    nwb(iFiles).export(filename);
 end
 end

--- a/nwbRead.m
+++ b/nwbRead.m
@@ -17,8 +17,15 @@ function nwb = nwbRead(filename, varargin)
 %
 %  See also GENERATECORE, GENERATEEXTENSION, NWBFILE, NWBEXPORT
 
-assert(iscellstr(varargin), 'NWB:NWBRead:InvalidParameters',...
-    'Optional parameters must all be character arrays.'); %#ok<ISCLSTR>
+for iOption = 1:length(varargin)
+    option = varargin{iOption};
+    if isstring(option)
+        option = char(option);
+    end
+    assert(ischar(option), 'NWB:Read:InvalidParameter' ...
+        , 'Invalid optional parameter in argument position %u', 1 + iOption);
+    varargin{iOption} = option;
+end
 
 ignoreCache = any(strcmpi(varargin, 'ignorecache'));
 
@@ -34,8 +41,10 @@ end
 Blacklist = struct(...
     'attributes', {{'.specloc', 'object_id'}},...
     'groups', {{}});
-validateattributes(filename, {'char', 'string'}, {'scalartext', 'nonempty'});
+validateattributes(filename, {'char', 'string'}, {'scalartext', 'nonempty'} ...
+    , 'nwbRead', 'filename', 1);
 
+filename = char(filename);
 specLocation = getEmbeddedSpec(filename);
 if ~isempty(specLocation)
     Blacklist.groups{end+1} = specLocation;

--- a/nwbRead.m
+++ b/nwbRead.m
@@ -1,165 +1,165 @@
 function nwb = nwbRead(filename, varargin)
-%NWBREAD Reads an NWB file.
-%  nwb = NWBREAD(filename) Reads the nwb file at filename and returns an
-%  NWBFile object representing its contents.
-%  nwb = nwbRead(filename, 'ignorecache') Reads the nwb file without generating classes
-%  off of the cached schema if one exists.
-%
-%  nwb = NWBREAD(filename, options)
-%
-%  Requires that core and extension NWB types have been generated
-%  and reside in a 'types' package on the matlab path.
-%
-%  Example:
-%    nwb = nwbRead('data.nwb');
-%    nwb = nwbRead('data.nwb', 'ignorecache');
-%    nwb = nwbRead('data.nwb', 'savedir', '.');
-%
-%  See also GENERATECORE, GENERATEEXTENSION, NWBFILE, NWBEXPORT
-
-for iOption = 1:length(varargin)
-    option = varargin{iOption};
-    if isstring(option)
-        option = char(option);
-    end
-    assert(ischar(option), 'NWB:Read:InvalidParameter' ...
-        , 'Invalid optional parameter in argument position %u', 1 + iOption);
-    varargin{iOption} = option;
-end
-
-ignoreCache = any(strcmpi(varargin, 'ignorecache'));
-
-saveDirMask = strcmpi(varargin, 'savedir');
-assert(isempty(saveDirMask) || ~saveDirMask(end), 'NWB:NWBRead:InvalidSaveDir',...
-    '`savedir` is a key value pair requiring a directory string as a value.');
-if any(saveDirMask)
-    saveDir = varargin{find(saveDirMask, 1, 'last') + 1};
-else
-    saveDir = misc.getMatnwbDir();
-end
-
-Blacklist = struct(...
-    'attributes', {{'.specloc', 'object_id'}},...
-    'groups', {{}});
-validateattributes(filename, {'char', 'string'}, {'scalartext', 'nonempty'} ...
-    , 'nwbRead', 'filename', 1);
-
-filename = char(filename);
-specLocation = getEmbeddedSpec(filename);
-if ~isempty(specLocation)
-    Blacklist.groups{end+1} = specLocation;
-end
-
-if ~ignoreCache
-    if isempty(specLocation)
-        try
-            generateCore(util.getSchemaVersion(filename), 'savedir', saveDir);
-        catch ME
-            if ~strcmp(ME.identifier, 'NWB:GenerateCore:MissingCoreSchema')
-                rethrow(ME);
-            end
+    %NWBREAD Reads an NWB file.
+    %  nwb = NWBREAD(filename) Reads the nwb file at filename and returns an
+    %  NWBFile object representing its contents.
+    %  nwb = nwbRead(filename, 'ignorecache') Reads the nwb file without generating classes
+    %  off of the cached schema if one exists.
+    %
+    %  nwb = NWBREAD(filename, options)
+    %
+    %  Requires that core and extension NWB types have been generated
+    %  and reside in a 'types' package on the matlab path.
+    %
+    %  Example:
+    %    nwb = nwbRead('data.nwb');
+    %    nwb = nwbRead('data.nwb', 'ignorecache');
+    %    nwb = nwbRead('data.nwb', 'savedir', '.');
+    %
+    %  See also GENERATECORE, GENERATEEXTENSION, NWBFILE, NWBEXPORT
+    
+    for iOption = 1:length(varargin)
+        option = varargin{iOption};
+        if isstring(option)
+            option = char(option);
         end
-    else
-        generateSpec(filename, h5info(filename, specLocation), 'savedir', saveDir);
+        assert(ischar(option), 'NWB:Read:InvalidParameter' ...
+            , 'Invalid optional parameter in argument position %u', 1 + iOption);
+        varargin{iOption} = option;
     end
-    rehash();
-end
-
-nwb = io.parseGroup(filename, h5info(filename), Blacklist);
+    
+    ignoreCache = any(strcmpi(varargin, 'ignorecache'));
+    
+    saveDirMask = strcmpi(varargin, 'savedir');
+    assert(isempty(saveDirMask) || ~saveDirMask(end), 'NWB:NWBRead:InvalidSaveDir',...
+        '`savedir` is a key value pair requiring a directory string as a value.');
+    if any(saveDirMask)
+        saveDir = varargin{find(saveDirMask, 1, 'last') + 1};
+    else
+        saveDir = misc.getMatnwbDir();
+    end
+    
+    Blacklist = struct(...
+        'attributes', {{'.specloc', 'object_id'}},...
+        'groups', {{}});
+    validateattributes(filename, {'char', 'string'}, {'scalartext', 'nonempty'} ...
+        , 'nwbRead', 'filename', 1);
+    
+    filename = char(filename);
+    specLocation = getEmbeddedSpec(filename);
+    if ~isempty(specLocation)
+        Blacklist.groups{end+1} = specLocation;
+    end
+    
+    if ~ignoreCache
+        if isempty(specLocation)
+            try
+                generateCore(util.getSchemaVersion(filename), 'savedir', saveDir);
+            catch ME
+                if ~strcmp(ME.identifier, 'NWB:GenerateCore:MissingCoreSchema')
+                    rethrow(ME);
+                end
+            end
+        else
+            generateSpec(filename, h5info(filename, specLocation), 'savedir', saveDir);
+        end
+        rehash();
+    end
+    
+    nwb = io.parseGroup(filename, h5info(filename), Blacklist);
 end
 
 function specLocation = getEmbeddedSpec(filename)
-specLocation = '';
-fid = H5F.open(filename);
-try
-    %check for .specloc
-    attributeId = H5A.open(fid, '.specloc');
-    referenceRawData = H5A.read(attributeId);
-    specLocation = H5R.get_name(attributeId, 'H5R_OBJECT', referenceRawData);
-    H5A.close(attributeId);
-catch ME
-    if ~strcmp(ME.identifier, 'MATLAB:imagesci:hdf5lib:libraryError')
-        rethrow(ME);
-    end % don't error if the attribute doesn't exist.
-end
-
-H5F.close(fid);
+    specLocation = '';
+    fid = H5F.open(filename);
+    try
+        %check for .specloc
+        attributeId = H5A.open(fid, '.specloc');
+        referenceRawData = H5A.read(attributeId);
+        specLocation = H5R.get_name(attributeId, 'H5R_OBJECT', referenceRawData);
+        H5A.close(attributeId);
+    catch ME
+        if ~strcmp(ME.identifier, 'MATLAB:imagesci:hdf5lib:libraryError')
+            rethrow(ME);
+        end % don't error if the attribute doesn't exist.
+    end
+    
+    H5F.close(fid);
 end
 
 function generateSpec(filename, specinfo, varargin)
-saveDirMask = strcmp(varargin, 'savedir');
-if any(saveDirMask)
-    assert(~saveDirMask(end),...
-        'NWB:Read:InvalidParameter',...
-        'savedir must be paired with the desired save directory.');
-    saveDir = varargin{find(saveDirMask, 1, 'last') + 1};
-else
-    saveDir = misc.getMatnwbDir();
-end
-
-specNames = cell(size(specinfo.Groups));
-fid = H5F.open(filename);
-for iGroup = 1:length(specinfo.Groups)
-    location = specinfo.Groups(iGroup).Groups(1);
-    
-    namespaceName = split(specinfo.Groups(iGroup).Name, '/');
-    namespaceName = namespaceName{end};
-    
-    filenames = {location.Datasets.Name};
-    if ~any(strcmp('namespace', filenames))
-        warning('NWB:Read:GenerateSpec:CacheInvalid',...
-        'Couldn''t find a `namespace` in namespace `%s`.  Skipping cache generation.',...
-        namespaceName);
-        return;
+    saveDirMask = strcmp(varargin, 'savedir');
+    if any(saveDirMask)
+        assert(~saveDirMask(end),...
+            'NWB:Read:InvalidParameter',...
+            'savedir must be paired with the desired save directory.');
+        saveDir = varargin{find(saveDirMask, 1, 'last') + 1};
+    else
+        saveDir = misc.getMatnwbDir();
     end
-    sourceNames = {location.Datasets.Name};
-    fileLocation = strcat(location.Name, '/', sourceNames);
-    schemaMap = containers.Map;
-    for iFileLocation = 1:length(fileLocation)
-        did = H5D.open(fid, fileLocation{iFileLocation});
-        if strcmp('namespace', sourceNames{iFileLocation})
-            namespaceText = H5D.read(did);
-        else
-            schemaMap(sourceNames{iFileLocation}) = H5D.read(did);    
+    
+    specNames = cell(size(specinfo.Groups));
+    fid = H5F.open(filename);
+    for iGroup = 1:length(specinfo.Groups)
+        location = specinfo.Groups(iGroup).Groups(1);
+        
+        namespaceName = split(specinfo.Groups(iGroup).Name, '/');
+        namespaceName = namespaceName{end};
+        
+        filenames = {location.Datasets.Name};
+        if ~any(strcmp('namespace', filenames))
+            warning('NWB:Read:GenerateSpec:CacheInvalid',...
+                'Couldn''t find a `namespace` in namespace `%s`.  Skipping cache generation.',...
+                namespaceName);
+            return;
         end
-        H5D.close(did);
-    end
-    
-    Namespaces = spec.generate(namespaceText, schemaMap);
-    % Handle embedded namespaces.
-    Namespace = Namespaces(strcmp({Namespaces.name}, namespaceName));
-    if isempty(Namespace)
-        % legacy checks in case namespaceName is using the old underscore
-        % conversion name.
-        namespaceName = strrep(namespaceName, '_', '-');
+        sourceNames = {location.Datasets.Name};
+        fileLocation = strcat(location.Name, '/', sourceNames);
+        schemaMap = containers.Map;
+        for iFileLocation = 1:length(fileLocation)
+            did = H5D.open(fid, fileLocation{iFileLocation});
+            if strcmp('namespace', sourceNames{iFileLocation})
+                namespaceText = H5D.read(did);
+            else
+                schemaMap(sourceNames{iFileLocation}) = H5D.read(did);
+            end
+            H5D.close(did);
+        end
+        
+        Namespaces = spec.generate(namespaceText, schemaMap);
+        % Handle embedded namespaces.
         Namespace = Namespaces(strcmp({Namespaces.name}, namespaceName));
+        if isempty(Namespace)
+            % legacy checks in case namespaceName is using the old underscore
+            % conversion name.
+            namespaceName = strrep(namespaceName, '_', '-');
+            Namespace = Namespaces(strcmp({Namespaces.name}, namespaceName));
+        end
+        
+        assert(~isempty(Namespace), ...
+            'NWB:Namespace:NameNotFound', ...
+            'Namespace %s not found in schema. Perhaps an extension should be generated?', ...
+            namespaceName);
+        
+        spec.saveCache(Namespace, saveDir);
+        specNames{iGroup} = Namespace.name;
     end
-
-    assert(~isempty(Namespace), ...
-        'NWB:Namespace:NameNotFound', ...
-        'Namespace %s not found in schema. Perhaps an extension should be generated?', ...
-        namespaceName);
+    H5F.close(fid);
     
-    spec.saveCache(Namespace, saveDir);
-    specNames{iGroup} = Namespace.name;
-end
-H5F.close(fid);
-
-missingNames = cell(size(specNames));
-for iName = 1:length(specNames)
-    name = specNames{iName};
-    try
-        file.writeNamespace(name, saveDir);
-    catch ME
-        if strcmp(ME.identifier, 'NWB:Namespace:CacheMissing')
-            missingNames{iName} = name;
-        else
-            rethrow(ME);
+    missingNames = cell(size(specNames));
+    for iName = 1:length(specNames)
+        name = specNames{iName};
+        try
+            file.writeNamespace(name, saveDir);
+        catch ME
+            if strcmp(ME.identifier, 'NWB:Namespace:CacheMissing')
+                missingNames{iName} = name;
+            else
+                rethrow(ME);
+            end
         end
     end
-end
-missingNames(cellfun('isempty', missingNames)) = [];
-assert(isempty(missingNames), 'NWB:Namespace:DependencyMissing',...
-    'Missing generated caches and dependent caches for the following namespaces:\n%s',...
-            misc.cellPrettyPrint(missingNames));
+    missingNames(cellfun('isempty', missingNames)) = [];
+    assert(isempty(missingNames), 'NWB:Namespace:DependencyMissing',...
+        'Missing generated caches and dependent caches for the following namespaces:\n%s',...
+        misc.cellPrettyPrint(missingNames));
 end


### PR DESCRIPTION
Fixes #287 
## Motivation

Allow for strings since these may be used by users.

## How to test the behavior?

Using any of the `generateCore`, `generateExtension`, `nwbRead`, or `nwbExport` with double-quotes instead of single quotes should not cause errors.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
