### PR TITLE
shrink int to auto-map to int8

### DIFF
--- a/+file/mapType.m
+++ b/+file/mapType.m
@@ -43,7 +43,7 @@ switch dtype
     case 'long'
         dt = 'int64';
     case 'int'
-        dt = 'int32';
+        dt = 'int8';
     case 'short'
         dt = 'int16';
     otherwise


### PR DESCRIPTION
Fixes #486 

## Motivation

Allows auto-shrink to all integer types.

## How to test the behavior?

tests should be successful when exported by MatNWB and read in by PyNWB.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
