### PR TITLE
Add warning when schema is not supported

### DIFF
--- a/nwbRead.m
+++ b/nwbRead.m
@@ -46,14 +46,25 @@ function nwb = nwbRead(filename, varargin)
     
     filename = char(filename);
     specLocation = getEmbeddedSpec(filename);
+    schemaVersion = util.getSchemaVersion(filename);
     if ~isempty(specLocation)
         Blacklist.groups{end+1} = specLocation;
+    end
+
+    % validate supported schema version
+    Schemas = dir(fullfile(misc.getMatnwbDir(), 'nwb-schema'));
+    supportedSchemas = setdiff({Schemas.name}, {'.', '..'});
+    if ~any(strcmp(schemaVersion, supportedSchemas))
+        warning('NWB:Read:UnsupportedSchema' ...
+            , ['NWB schema version %s is not support by this version of MatNWB. ' ...
+            'This file is not guaranteed to be supported.'] ...
+            , schemaVersion);
     end
     
     if ~ignoreCache
         if isempty(specLocation)
             try
-                generateCore(util.getSchemaVersion(filename), 'savedir', saveDir);
+                generateCore(schemaVersion, 'savedir', saveDir);
             catch ME
                 if ~strcmp(ME.identifier, 'NWB:GenerateCore:MissingCoreSchema')
                     rethrow(ME);


### PR DESCRIPTION
## Motivation

Fixes #499 

## How to test the behavior?
Attempt to call `nwbRead` on a file using a non-standard schema.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
