### PR TITLE
Update PyNWBIOTest.m

### DIFF
--- a/+tests/+system/PyNWBIOTest.m
+++ b/+tests/+system/PyNWBIOTest.m
@@ -38,9 +38,12 @@ classdef PyNWBIOTest < tests.system.RoundTripTest
             
             envPath = fullfile('+tests', 'env.mat');
             if 2 == exist(envPath, 'file')
-                Env = load(envPath, '-mat', 'pythonDir');
-                
-                pythonPath = fullfile(Env.pythonDir, 'python');
+                Env = load(envPath, '-mat');
+                if isfield(Env, 'pythonPath')
+                    pythonPath = Env.pythonPath;
+                else
+                    pythonPath = fullfile(Env.pythonDir, 'python');
+                end
             else
                 pythonPath = 'python';
             end


### PR DESCRIPTION
Added pythonPath as a variable that can be loaded from env.mat. pythonDir option does not work if the python executable is named python3

## Motivation

Can not run python-related tests if the python executable is named python3

## How to test the behavior?
```
N/A
```

## Checklist

- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
