### PR TITLE
Issue 584: Add warning on export if some attributes are not written to file

### DIFF
--- a/+tests/+unit/nwbExportTest.m
+++ b/+tests/+unit/nwbExportTest.m
@@ -1,0 +1,60 @@
+classdef nwbExportTest < matlab.unittest.TestCase
+
+    properties
+        NwbObject
+    end
+
+    methods (TestClassSetup)
+        function setupClass(testCase)
+            % Get the root path of the matnwb repository
+            rootPath = misc.getMatnwbDir();
+
+            % Use a fixture to add the folder to the search path
+            testCase.applyFixture(matlab.unittest.fixtures.PathFixture(rootPath));
+        end
+    end
+
+    methods (TestMethodSetup)
+        function setupMethod(testCase)
+            % Use a fixture to create a temporary working directory
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+            testCase.NwbObject = testCase.initNwbFile();
+        end
+    end
+
+    methods (Test)
+        function testExportDependentAttributeWithMissingParentA(testCase)
+            testCase.NwbObject.general_source_script_file_name = 'my_test_script.m';
+            testCase.verifyWarning(@(f, fn) nwbExport(testCase.NwbObject, 'test_part1.nwb'), 'NWB:DependentAttributeNotExported')
+            
+            % Add value for dataset which attribute depends on and export again
+            testCase.NwbObject.general_source_script = 'my test';
+            testCase.verifyWarningFree(@(f, fn) nwbExport(testCase.NwbObject, 'test_part2.nwb'))
+        end
+
+        function testExportDependentAttributeWithMissingParentB(testCase)
+            time_series = types.core.TimeSeries( ...
+                'data', linspace(0, 0.4, 50), ...
+                'starting_time_rate', 10.0, ...
+                'description', 'a test series', ...
+                'data_unit', 'n/a' ...
+            );
+
+            testCase.NwbObject.acquisition.set('time_series', time_series);
+            testCase.verifyWarning(@(f, fn) nwbExport(testCase.NwbObject, 'test_part1.nwb'), 'NWB:DependentAttributeNotExported')
+
+            % Add value for dataset which attribute depends on and export again
+            time_series.starting_time = 1;
+            testCase.verifyWarningFree(@(f, fn) nwbExport(testCase.NwbObject, 'test_part2.nwb'))
+        end
+    end
+
+    methods (Static)
+        function nwb = initNwbFile()
+            nwb = NwbFile( ...
+                'session_description', 'test file for nwb export', ...
+                'identifier', 'export_test', ...
+                'session_start_time', datetime("now", 'TimeZone', 'local') );
+        end
+    end
+end

--- a/+types/+core/ImageSeries.m
+++ b/+types/+core/ImageSeries.m
@@ -175,6 +175,8 @@ methods
         end
         if ~isempty(obj.external_file) && ~isa(obj.external_file, 'types.untyped.SoftLink') && ~isa(obj.external_file, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/external_file/starting_frame'], obj.external_file_starting_frame, 'forceArray');
+        elseif isempty(obj.external_file) && ~isempty(obj.external_file_starting_frame)
+            obj.warnIfPropertyAttributeNotExported('external_file_starting_frame', 'external_file', fullpath)
         end
         if ~isempty(obj.format)
             if startsWith(class(obj.format), 'types.untyped.')

--- a/+types/+core/ImagingPlane.m
+++ b/+types/+core/ImagingPlane.m
@@ -388,6 +388,8 @@ methods
         end
         if ~isempty(obj.grid_spacing) && ~isa(obj.grid_spacing, 'types.untyped.SoftLink') && ~isa(obj.grid_spacing, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/grid_spacing/unit'], obj.grid_spacing_unit);
+        elseif isempty(obj.grid_spacing) && ~isempty(obj.grid_spacing_unit)
+            obj.warnIfPropertyAttributeNotExported('grid_spacing_unit', 'grid_spacing', fullpath)
         end
         if ~isempty(obj.imaging_rate)
             if startsWith(class(obj.imaging_rate), 'types.untyped.')
@@ -429,6 +431,8 @@ methods
         end
         if ~isempty(obj.origin_coords) && ~isa(obj.origin_coords, 'types.untyped.SoftLink') && ~isa(obj.origin_coords, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/origin_coords/unit'], obj.origin_coords_unit);
+        elseif isempty(obj.origin_coords) && ~isempty(obj.origin_coords_unit)
+            obj.warnIfPropertyAttributeNotExported('origin_coords_unit', 'origin_coords', fullpath)
         end
         if ~isempty(obj.reference_frame)
             if startsWith(class(obj.reference_frame), 'types.untyped.')

--- a/+types/+core/ImagingRetinotopy.m
+++ b/+types/+core/ImagingRetinotopy.m
@@ -785,12 +785,18 @@ methods
         end
         if ~isempty(obj.axis_1_phase_map) && ~isa(obj.axis_1_phase_map, 'types.untyped.SoftLink') && ~isa(obj.axis_1_phase_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_1_phase_map/dimension'], obj.axis_1_phase_map_dimension, 'forceArray');
+        elseif isempty(obj.axis_1_phase_map) && ~isempty(obj.axis_1_phase_map_dimension)
+            obj.warnIfPropertyAttributeNotExported('axis_1_phase_map_dimension', 'axis_1_phase_map', fullpath)
         end
         if ~isempty(obj.axis_1_phase_map) && ~isa(obj.axis_1_phase_map, 'types.untyped.SoftLink') && ~isa(obj.axis_1_phase_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_1_phase_map/field_of_view'], obj.axis_1_phase_map_field_of_view, 'forceArray');
+        elseif isempty(obj.axis_1_phase_map) && ~isempty(obj.axis_1_phase_map_field_of_view)
+            obj.warnIfPropertyAttributeNotExported('axis_1_phase_map_field_of_view', 'axis_1_phase_map', fullpath)
         end
         if ~isempty(obj.axis_1_phase_map) && ~isa(obj.axis_1_phase_map, 'types.untyped.SoftLink') && ~isa(obj.axis_1_phase_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_1_phase_map/unit'], obj.axis_1_phase_map_unit);
+        elseif isempty(obj.axis_1_phase_map) && ~isempty(obj.axis_1_phase_map_unit)
+            obj.warnIfPropertyAttributeNotExported('axis_1_phase_map_unit', 'axis_1_phase_map', fullpath)
         end
         if ~isempty(obj.axis_1_power_map)
             if startsWith(class(obj.axis_1_power_map), 'types.untyped.')
@@ -801,12 +807,18 @@ methods
         end
         if ~isempty(obj.axis_1_power_map) && ~isa(obj.axis_1_power_map, 'types.untyped.SoftLink') && ~isa(obj.axis_1_power_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_1_power_map/dimension'], obj.axis_1_power_map_dimension, 'forceArray');
+        elseif isempty(obj.axis_1_power_map) && ~isempty(obj.axis_1_power_map_dimension)
+            obj.warnIfPropertyAttributeNotExported('axis_1_power_map_dimension', 'axis_1_power_map', fullpath)
         end
         if ~isempty(obj.axis_1_power_map) && ~isa(obj.axis_1_power_map, 'types.untyped.SoftLink') && ~isa(obj.axis_1_power_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_1_power_map/field_of_view'], obj.axis_1_power_map_field_of_view, 'forceArray');
+        elseif isempty(obj.axis_1_power_map) && ~isempty(obj.axis_1_power_map_field_of_view)
+            obj.warnIfPropertyAttributeNotExported('axis_1_power_map_field_of_view', 'axis_1_power_map', fullpath)
         end
         if ~isempty(obj.axis_1_power_map) && ~isa(obj.axis_1_power_map, 'types.untyped.SoftLink') && ~isa(obj.axis_1_power_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_1_power_map/unit'], obj.axis_1_power_map_unit);
+        elseif isempty(obj.axis_1_power_map) && ~isempty(obj.axis_1_power_map_unit)
+            obj.warnIfPropertyAttributeNotExported('axis_1_power_map_unit', 'axis_1_power_map', fullpath)
         end
         if startsWith(class(obj.axis_2_phase_map), 'types.untyped.')
             refs = obj.axis_2_phase_map.export(fid, [fullpath '/axis_2_phase_map'], refs);
@@ -815,12 +827,18 @@ methods
         end
         if ~isempty(obj.axis_2_phase_map) && ~isa(obj.axis_2_phase_map, 'types.untyped.SoftLink') && ~isa(obj.axis_2_phase_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_2_phase_map/dimension'], obj.axis_2_phase_map_dimension, 'forceArray');
+        elseif isempty(obj.axis_2_phase_map) && ~isempty(obj.axis_2_phase_map_dimension)
+            obj.warnIfPropertyAttributeNotExported('axis_2_phase_map_dimension', 'axis_2_phase_map', fullpath)
         end
         if ~isempty(obj.axis_2_phase_map) && ~isa(obj.axis_2_phase_map, 'types.untyped.SoftLink') && ~isa(obj.axis_2_phase_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_2_phase_map/field_of_view'], obj.axis_2_phase_map_field_of_view, 'forceArray');
+        elseif isempty(obj.axis_2_phase_map) && ~isempty(obj.axis_2_phase_map_field_of_view)
+            obj.warnIfPropertyAttributeNotExported('axis_2_phase_map_field_of_view', 'axis_2_phase_map', fullpath)
         end
         if ~isempty(obj.axis_2_phase_map) && ~isa(obj.axis_2_phase_map, 'types.untyped.SoftLink') && ~isa(obj.axis_2_phase_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_2_phase_map/unit'], obj.axis_2_phase_map_unit);
+        elseif isempty(obj.axis_2_phase_map) && ~isempty(obj.axis_2_phase_map_unit)
+            obj.warnIfPropertyAttributeNotExported('axis_2_phase_map_unit', 'axis_2_phase_map', fullpath)
         end
         if ~isempty(obj.axis_2_power_map)
             if startsWith(class(obj.axis_2_power_map), 'types.untyped.')
@@ -831,12 +849,18 @@ methods
         end
         if ~isempty(obj.axis_2_power_map) && ~isa(obj.axis_2_power_map, 'types.untyped.SoftLink') && ~isa(obj.axis_2_power_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_2_power_map/dimension'], obj.axis_2_power_map_dimension, 'forceArray');
+        elseif isempty(obj.axis_2_power_map) && ~isempty(obj.axis_2_power_map_dimension)
+            obj.warnIfPropertyAttributeNotExported('axis_2_power_map_dimension', 'axis_2_power_map', fullpath)
         end
         if ~isempty(obj.axis_2_power_map) && ~isa(obj.axis_2_power_map, 'types.untyped.SoftLink') && ~isa(obj.axis_2_power_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_2_power_map/field_of_view'], obj.axis_2_power_map_field_of_view, 'forceArray');
+        elseif isempty(obj.axis_2_power_map) && ~isempty(obj.axis_2_power_map_field_of_view)
+            obj.warnIfPropertyAttributeNotExported('axis_2_power_map_field_of_view', 'axis_2_power_map', fullpath)
         end
         if ~isempty(obj.axis_2_power_map) && ~isa(obj.axis_2_power_map, 'types.untyped.SoftLink') && ~isa(obj.axis_2_power_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/axis_2_power_map/unit'], obj.axis_2_power_map_unit);
+        elseif isempty(obj.axis_2_power_map) && ~isempty(obj.axis_2_power_map_unit)
+            obj.warnIfPropertyAttributeNotExported('axis_2_power_map_unit', 'axis_2_power_map', fullpath)
         end
         if startsWith(class(obj.axis_descriptions), 'types.untyped.')
             refs = obj.axis_descriptions.export(fid, [fullpath '/axis_descriptions'], refs);
@@ -852,18 +876,28 @@ methods
         end
         if ~isempty(obj.focal_depth_image) && ~isa(obj.focal_depth_image, 'types.untyped.SoftLink') && ~isa(obj.focal_depth_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/focal_depth_image/bits_per_pixel'], obj.focal_depth_image_bits_per_pixel);
+        elseif isempty(obj.focal_depth_image) && ~isempty(obj.focal_depth_image_bits_per_pixel)
+            obj.warnIfPropertyAttributeNotExported('focal_depth_image_bits_per_pixel', 'focal_depth_image', fullpath)
         end
         if ~isempty(obj.focal_depth_image) && ~isa(obj.focal_depth_image, 'types.untyped.SoftLink') && ~isa(obj.focal_depth_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/focal_depth_image/dimension'], obj.focal_depth_image_dimension, 'forceArray');
+        elseif isempty(obj.focal_depth_image) && ~isempty(obj.focal_depth_image_dimension)
+            obj.warnIfPropertyAttributeNotExported('focal_depth_image_dimension', 'focal_depth_image', fullpath)
         end
         if ~isempty(obj.focal_depth_image) && ~isa(obj.focal_depth_image, 'types.untyped.SoftLink') && ~isa(obj.focal_depth_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/focal_depth_image/field_of_view'], obj.focal_depth_image_field_of_view, 'forceArray');
+        elseif isempty(obj.focal_depth_image) && ~isempty(obj.focal_depth_image_field_of_view)
+            obj.warnIfPropertyAttributeNotExported('focal_depth_image_field_of_view', 'focal_depth_image', fullpath)
         end
         if ~isempty(obj.focal_depth_image) && ~isa(obj.focal_depth_image, 'types.untyped.SoftLink') && ~isa(obj.focal_depth_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/focal_depth_image/focal_depth'], obj.focal_depth_image_focal_depth);
+        elseif isempty(obj.focal_depth_image) && ~isempty(obj.focal_depth_image_focal_depth)
+            obj.warnIfPropertyAttributeNotExported('focal_depth_image_focal_depth', 'focal_depth_image', fullpath)
         end
         if ~isempty(obj.focal_depth_image) && ~isa(obj.focal_depth_image, 'types.untyped.SoftLink') && ~isa(obj.focal_depth_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/focal_depth_image/format'], obj.focal_depth_image_format);
+        elseif isempty(obj.focal_depth_image) && ~isempty(obj.focal_depth_image_format)
+            obj.warnIfPropertyAttributeNotExported('focal_depth_image_format', 'focal_depth_image', fullpath)
         end
         if ~isempty(obj.sign_map)
             if startsWith(class(obj.sign_map), 'types.untyped.')
@@ -874,9 +908,13 @@ methods
         end
         if ~isempty(obj.sign_map) && ~isa(obj.sign_map, 'types.untyped.SoftLink') && ~isa(obj.sign_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/sign_map/dimension'], obj.sign_map_dimension, 'forceArray');
+        elseif isempty(obj.sign_map) && ~isempty(obj.sign_map_dimension)
+            obj.warnIfPropertyAttributeNotExported('sign_map_dimension', 'sign_map', fullpath)
         end
         if ~isempty(obj.sign_map) && ~isa(obj.sign_map, 'types.untyped.SoftLink') && ~isa(obj.sign_map, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/sign_map/field_of_view'], obj.sign_map_field_of_view, 'forceArray');
+        elseif isempty(obj.sign_map) && ~isempty(obj.sign_map_field_of_view)
+            obj.warnIfPropertyAttributeNotExported('sign_map_field_of_view', 'sign_map', fullpath)
         end
         if startsWith(class(obj.vasculature_image), 'types.untyped.')
             refs = obj.vasculature_image.export(fid, [fullpath '/vasculature_image'], refs);
@@ -885,15 +923,23 @@ methods
         end
         if ~isempty(obj.vasculature_image) && ~isa(obj.vasculature_image, 'types.untyped.SoftLink') && ~isa(obj.vasculature_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/vasculature_image/bits_per_pixel'], obj.vasculature_image_bits_per_pixel);
+        elseif isempty(obj.vasculature_image) && ~isempty(obj.vasculature_image_bits_per_pixel)
+            obj.warnIfPropertyAttributeNotExported('vasculature_image_bits_per_pixel', 'vasculature_image', fullpath)
         end
         if ~isempty(obj.vasculature_image) && ~isa(obj.vasculature_image, 'types.untyped.SoftLink') && ~isa(obj.vasculature_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/vasculature_image/dimension'], obj.vasculature_image_dimension, 'forceArray');
+        elseif isempty(obj.vasculature_image) && ~isempty(obj.vasculature_image_dimension)
+            obj.warnIfPropertyAttributeNotExported('vasculature_image_dimension', 'vasculature_image', fullpath)
         end
         if ~isempty(obj.vasculature_image) && ~isa(obj.vasculature_image, 'types.untyped.SoftLink') && ~isa(obj.vasculature_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/vasculature_image/field_of_view'], obj.vasculature_image_field_of_view, 'forceArray');
+        elseif isempty(obj.vasculature_image) && ~isempty(obj.vasculature_image_field_of_view)
+            obj.warnIfPropertyAttributeNotExported('vasculature_image_field_of_view', 'vasculature_image', fullpath)
         end
         if ~isempty(obj.vasculature_image) && ~isa(obj.vasculature_image, 'types.untyped.SoftLink') && ~isa(obj.vasculature_image, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/vasculature_image/format'], obj.vasculature_image_format);
+        elseif isempty(obj.vasculature_image) && ~isempty(obj.vasculature_image_format)
+            obj.warnIfPropertyAttributeNotExported('vasculature_image_format', 'vasculature_image', fullpath)
         end
     end
 end

--- a/+types/+core/NWBFile.m
+++ b/+types/+core/NWBFile.m
@@ -1010,6 +1010,8 @@ methods
         end
         if ~isempty(obj.general_source_script) && ~isa(obj.general_source_script, 'types.untyped.SoftLink') && ~isa(obj.general_source_script, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/general/source_script/file_name'], obj.general_source_script_file_name);
+        elseif isempty(obj.general_source_script) && ~isempty(obj.general_source_script_file_name)
+            obj.warnIfPropertyAttributeNotExported('general_source_script_file_name', 'general_source_script', fullpath)
         end
         io.writeGroup(fid, [fullpath '/general']);
         if ~isempty(obj.general_stimulus)

--- a/+types/+core/TimeSeries.m
+++ b/+types/+core/TimeSeries.m
@@ -380,6 +380,8 @@ methods
         end
         if ~isempty(obj.data) && ~isa(obj.data, 'types.untyped.SoftLink') && ~isa(obj.data, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/data/unit'], obj.data_unit);
+        elseif isempty(obj.data) && ~isempty(obj.data_unit)
+            obj.warnIfPropertyAttributeNotExported('data_unit', 'data', fullpath)
         end
         if ~isempty(obj.description)
             io.writeAttribute(fid, [fullpath '/description'], obj.description);
@@ -393,6 +395,8 @@ methods
         end
         if ~isempty(obj.starting_time) && ~isa(obj.starting_time, 'types.untyped.SoftLink') && ~isa(obj.starting_time, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/starting_time/rate'], obj.starting_time_rate);
+        elseif isempty(obj.starting_time) && ~isempty(obj.starting_time_rate)
+            obj.warnIfPropertyAttributeNotExported('starting_time_rate', 'starting_time', fullpath)
         end
         if ~isempty(obj.starting_time) && ~isa(obj.starting_time, 'types.untyped.SoftLink') && ~isa(obj.starting_time, 'types.untyped.ExternalLink')
             io.writeAttribute(fid, [fullpath '/starting_time/unit'], obj.starting_time_unit);

--- a/+types/+untyped/MetaClass.m
+++ b/+types/+untyped/MetaClass.m
@@ -95,5 +95,16 @@ classdef MetaClass < handle
                 end
             end
         end
+
+        function warnIfPropertyAttributeNotExported(obj, propName, depPropName, fullpath)
+            warnState = warning('backtrace', 'off');
+            cleanupObj = onCleanup(@(s) warning(warnState));
+            warningId = 'NWB:DependentAttributeNotExported';
+            warningMessage = sprintf( [ ...
+                'The property "%s" of type "%s" was not exported to file ', ...
+                'location "%s" because it depends on the property "%s" ', ...
+                'which is unset.' ], propName, class(obj), fullpath, depPropName);
+            warning(warningId, warningMessage) %#ok<SPWRN>
+        end
     end
 end


### PR DESCRIPTION
Fix #584

## Motivation

A subset of attributes will get dropped on nwbExport. These are attributes that are required, but depends on a dataset. When the dataset is empty, these values are not exported, but that happens silently. This fix adds a warning message on export if such cases are present.

## How to test the behavior?
```
tests.unit.nwbExportTest %(testExportDependentAttributeWithMissingParentA)
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
