### PR TITLE
Fix: Bug in writeCompound / parseCompound functions

### DIFF
--- a/+io/parseCompound.m
+++ b/+io/parseCompound.m
@@ -51,6 +51,12 @@ function data = parseCompound(datasetId, data)
     logicalFieldName = fieldName(isLogicalType);
     for iFieldName = 1:length(logicalFieldName)
         name = logicalFieldName{iFieldName};
-        data.(name) = strcmp('TRUE', data.(name));
+        if isa(data.(name), 'int8')
+            data.(name) = logical(data.(name));
+        elseif isa(data.(name), 'cell') && ismember(string(data.(name){1}), ["TRUE", "FALSE"])
+            data.(name) = strcmp('TRUE', data.(name));
+        else
+            error('NWB:ParseCompound:UnknownLogicalFormat', 'Could not resolve data of logical type')
+        end
     end
 end

--- a/+io/writeCompound.m
+++ b/+io/writeCompound.m
@@ -95,7 +95,7 @@ function writeCompound(fid, fullpath, data, varargin)
     % convert logical values
     boolNames = names(strcmp(classes, 'logical'));
     for iField = 1:length(boolNames)
-        data.(boolNames{iField}) = strcmp('TRUE', data.(boolNames{iField}));
+        data.(boolNames{iField}) = int8(data.(boolNames{iField}));
     end
 
     %transpose numeric column arrays to row arrays
@@ -134,6 +134,9 @@ function writeCompound(fid, fullpath, data, varargin)
                     warning('NWB:WriteCompund:ContinuousCompoundResize', ...
                         'Attempted to change size of continuous compound `%s`.  Skipping.', ...
                         fullpath);
+                    H5D.close(did);
+                    H5S.close(sid);
+                    return
                 end
             end
             H5P.close(create_plist);

--- a/+tests/+unit/+io/WriteTest.m
+++ b/+tests/+unit/+io/WriteTest.m
@@ -1,0 +1,70 @@
+classdef WriteTest < matlab.unittest.TestCase
+% WriteTest - Unit test for io.write* functions.
+
+    methods (TestMethodSetup)
+        function setup(testCase)
+            % Use a fixture to create a temporary working directory
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+        end
+    end
+
+    methods (Test)
+        
+        function testWriteBooleanAttribute(testCase)
+            filename = 'temp_test_file.h5';
+            fid = H5F.create(filename, 'H5F_ACC_TRUNC', 'H5P_DEFAULT', 'H5P_DEFAULT');
+            fileCleanupObj = onCleanup(@(id) H5F.close(fid));
+    
+            targetPath = '/';
+            io.writeGroup(fid, targetPath)
+
+            % Define target dataset path and create it in the HDF5 file
+            io.writeAttribute(fid, '/test', true);  % First write to create the dataset
+            
+            % Read using h5readatt and confirm value
+            value = h5readatt(filename, '/', 'test');
+            testCase.verifyTrue( strcmp(value, 'TRUE'))
+
+            % Read using io.parseAttributes and confirm value
+            blackList = struct(...
+                'attributes', {{'.specloc', 'object_id'}},...
+                'groups', {{}});   
+            
+            S = h5info(filename);
+            [attributeProperties, ~] =...
+                io.parseAttributes(filename, S.Attributes, S.Name, blackList);
+            testCase.verifyTrue(attributeProperties('test'))
+        end
+        
+        function testWriteCompound(testCase)
+            % Create a temporary HDF5 file
+            filename = 'temp_test_file.h5';
+            fullPath = '/test_dataset';
+            fid = H5F.create(filename, 'H5F_ACC_TRUNC', 'H5P_DEFAULT', 'H5P_DEFAULT');
+            fileCleanupObj = onCleanup(@(id) H5F.close(fid));
+            
+            % Data to write
+            data = struct('a', {1,2}, 'b', {true, false}, 'c', {'test', 'new test'});
+            io.writeCompound(fid, fullPath, data);  % First write to create the dataset
+            
+            loadedData = h5read(filename, '/test_dataset');
+            tempT = struct2table(loadedData);
+            % Booleans are loaded as int8, need to manually fix
+            tempT.b = logical( tempT.b );
+            loadedData = table2struct(tempT)';
+            testCase.verifyEqual(data, loadedData);
+
+            % Use parse compound
+            did = H5D.open(fid, '/test_dataset');
+            fsid = H5D.get_space(did);
+            loadedData = H5D.read(did, 'H5ML_DEFAULT', fsid, fsid,...
+                'H5P_DEFAULT');
+            data = io.parseCompound(did, loadedData);
+            H5S.close(fsid);
+            H5D.close(did);
+
+            parsedData = table2struct( struct2table(loadedData) )';
+            testCase.verifyEqual(data, parsedData);
+        end
+    end 
+end

--- a/+tests/+unit/+io/WriteTest.m
+++ b/+tests/+unit/+io/WriteTest.m
@@ -59,11 +59,11 @@ classdef WriteTest < matlab.unittest.TestCase
             fsid = H5D.get_space(did);
             loadedData = H5D.read(did, 'H5ML_DEFAULT', fsid, fsid,...
                 'H5P_DEFAULT');
-            data = io.parseCompound(did, loadedData);
+            parsedData = io.parseCompound(did, loadedData);
             H5S.close(fsid);
             H5D.close(did);
 
-            parsedData = table2struct( struct2table(loadedData) )';
+            parsedData = table2struct( struct2table(parsedData) )';
             testCase.verifyEqual(data, parsedData);
         end
     end 


### PR DESCRIPTION
## Motivation
The following lines in `io.writeCompound` always evaluates to `false`, because the value in the field of the data structure is per definition a logical array. It also evaluates to a scalar, so it will not work if the field value is a logical vector.

https://github.com/NeurodataWithoutBorders/matnwb/blob/d970ef16ea14c8e43a975740ca0f15d0e6899ac8/%2Bio/writeCompound.m#L96-L99

After fixing this, (for some reason which I don't know/understand) the respective part of parseCompound must also be updated:
https://github.com/NeurodataWithoutBorders/matnwb/blob/d970ef16ea14c8e43a975740ca0f15d0e6899ac8/%2Bio/parseCompound.m#L51-L55

The expected behavior (in matnwb) when writing logicals via the `int8` data type is that it will create an int8 enum type in the h5 file with values equal to `TRUE` or `FALSE`. However, when reading values back, the values are of type `int8`. The actual `tid` of the data (h5 type id) indicates that the data should be an "enum boolean", but the values are not. 

This might have something to do how the compound data type is set up in h5, but I do not know the hdf5 library, so I can't judge if the following should work or not:

https://github.com/NeurodataWithoutBorders/matnwb/blob/d970ef16ea14c8e43a975740ca0f15d0e6899ac8/%2Bio/writeCompound.m#L79-L83

The proposed fix does work in the unit test, and will also work if data would be read in as a "boolean enum" (TRUE/FALSE) values.

## How to test the behavior?
run unit tests in `tests.unit.io.WriteTest`

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
