### PR TITLE
Move tutorial tests from "tests.unit" to "tests.system.tutorial"

### DIFF
--- a/+tests/+system/+tutorial/PynwbTutorialTest.m
+++ b/+tests/+system/+tutorial/PynwbTutorialTest.m
@@ -136,7 +136,7 @@ classdef PynwbTutorialTest <  matlab.unittest.TestCase
             
             for i = 1:numel(nwbListing)
                 nwbFilename = nwbListing(i).name;
-                if any(strcmp(nwbFilename, tests.unit.PynwbTutorialTest.SkippedFiles))
+                if any(strcmp(nwbFilename, tests.system.tutorial.PynwbTutorialTest.SkippedFiles))
                     continue
                 end
 
@@ -213,12 +213,12 @@ function tutorialNames = listTutorialFiles()
 
     % Exclude skipped files.
     fileNames = strcat(fileNames(keep), '.py');
-    [~, iA] = setdiff(fileNames, tests.unit.PynwbTutorialTest.SkippedTutorials, 'stable');
+    [~, iA] = setdiff(fileNames, tests.system.tutorial.PynwbTutorialTest.SkippedTutorials, 'stable');
     tutorialNames = allFilePaths(iA);
 end
 
 function folderPath = getMatNwbRootDirectory()
-    folderPath = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+    folderPath = fileparts(fileparts(fileparts(fileparts(mfilename('fullpath')))));
 end
 
 function pynwbFolder = downloadPynwb()

--- a/+tests/+system/+tutorial/TutorialTest.m
+++ b/+tests/+system/+tutorial/TutorialTest.m
@@ -159,7 +159,7 @@ classdef (SharedTestFixtures = {tests.fixtures.NwbTypeGeneratorFixture}) ...
     methods (Static)
         function resultsOut = convertNwbInspectorResultsToStruct(resultsIn)
             
-            resultsOut = tests.unit.TutorialTest.getEmptyNwbInspectorResultStruct();
+            resultsOut = tests.system.tutorial.TutorialTest.getEmptyNwbInspectorResultStruct();
                     
             C = cell(resultsIn);
             for i = 1:numel(C)
@@ -179,7 +179,7 @@ classdef (SharedTestFixtures = {tests.fixtures.NwbTypeGeneratorFixture}) ...
         end
     
         function resultsOut = parseNWBInspectorTextOutput(systemCommandOutput)
-            resultsOut = tests.unit.TutorialTest.getEmptyNwbInspectorResultStruct();
+            resultsOut = tests.system.tutorial.TutorialTest.getEmptyNwbInspectorResultStruct();
             
             importanceLevels = containers.Map(...
                 ["BEST_PRACTICE_SUGGESTION", ...
@@ -265,5 +265,5 @@ function tutorialNames = listTutorialFiles()
         );
 
     L( [L.isdir] ) = []; % Ignore folders
-    tutorialNames = setdiff({L.name}, tests.unit.TutorialTest.SkippedTutorials);
+    tutorialNames = setdiff({L.name}, tests.system.tutorial.TutorialTest.SkippedTutorials);
 end


### PR DESCRIPTION
## Motivation

Better separation of namespaces, making it easier to run test subsets

# How to test the behavior? 
```
N/A
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
