### PR TITLE
Refactor: Replace try/catch with if/else in types.untyped.ObjectView

### DIFF
--- a/+types/+untyped/ObjectView.m
+++ b/+types/+untyped/ObjectView.m
@@ -62,12 +62,12 @@ classdef ObjectView < handle
                 path = obj.path;
             end
         end
-        
+
         function tf = has_path(obj)
-            try
+            if ~isempty(obj.target)
+                tf = ~isempty(obj.target.metaClass_fullPath);
+            else
                 tf = ~isempty(obj.path);
-            catch
-                tf = false;
             end
         end
     end


### PR DESCRIPTION
## Motivation
**Background**
Profiling during unit testing revealed a significant performance overhead due to the use of a try/catch block in the `has_path` method. Try/catch is designed for handling exceptions rather than routine flow control, and in this context it was unnecessarily impacting performance.

**Changes:**

- Refactored `has_path`:
The implementation has been replaced with a direct if/else check. This avoids the try/catch overhead while maintaining the same logical behavior.

**Benefits**
Removing the try/catch block reduces overhead, particularly noticeable when the method is called frequently, as it is during unit testing

## How to test the behavior?
```
N/A
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
