### PR TITLE
Fix compatibility issue in io.writeCompound for MATLAB R2019b and earlier

### DIFF
--- a/+io/writeCompound.m
+++ b/+io/writeCompound.m
@@ -92,6 +92,20 @@ function writeCompound(fid, fullpath, data, varargin)
     isReferenceClass = strcmp(classes, 'types.untyped.ObjectView') |...
         strcmp(classes, 'types.untyped.RegionView');
 
+    if verLessThan('matlab', '9.8') % Matlab < 2020a
+    % For MATLAB releases earlier than R2020a, character vectors must be
+    % wrapped in a cell array, otherwise the write operation will fail with
+    % the following error id "MATLAB:imagesci:hdf5dataset:badInputClass"
+    % and message "The class of input data must be cellstring instead of char
+    % when the HDF5 class is VARIABLE LENGTH H5T_STRING."
+        for i = 1:length(names)
+            val = data.(names{i});
+            if ischar(val)
+                data.(names{i}) = {data.(names{i})};
+            end
+        end
+    end
+    
     % convert logical values
     boolNames = names(strcmp(classes, 'logical'));
     for iField = 1:length(boolNames)

--- a/+tests/+unit/+io/WriteTest.m
+++ b/+tests/+unit/+io/WriteTest.m
@@ -86,6 +86,32 @@ classdef WriteTest < matlab.unittest.TestCase
             parsedData = table2struct( struct2table(parsedData) )';
             testCase.verifyEqual(data, parsedData);
         end
+        
+        function testWriteCompoundMap(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
+            fid = H5F.create('test.h5');
+            data = containers.Map({'a', 'b'}, 1:2);
+            io.writeCompound(fid, '/map_data', data)
+            H5F.close(fid);
+        end
+        
+        function testWriteCompoundEmpty(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
+            fid = H5F.create('test.h5');
+            data = struct;
+            testCase.verifyError(...
+                @(varargin) io.writeCompound(fid, '/map_data', data), ...
+                'MATLAB:imagesci:hdf5lib:libraryError')
+            H5F.close(fid);
+        end
+        
+        function testWriteCompoundScalar(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
+            fid = H5F.create('test.h5');
+            data = struct('a','b');
+            io.writeCompound(fid, '/map_data', data)
+            H5F.close(fid);
+        end
 
         function testWriteCompoundOverWrite(testCase)
                    

--- a/+tests/+unit/+io/WriteTest.m
+++ b/+tests/+unit/+io/WriteTest.m
@@ -113,6 +113,20 @@ classdef WriteTest < matlab.unittest.TestCase
             H5F.close(fid);
         end
 
+        function testWriteCompoundNonScalar(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
+            
+            numRows = 5;
+            numericVector = rand(numRows, 1);
+            charVector = char(randi([65 90], numRows, 1));
+            %stringVector = string(char(randi([65 90], numRows, 1)));
+            data = table(numericVector, charVector);
+                        
+            fid = H5F.create('test.h5');
+            io.writeCompound(fid, '/map_data', data)
+            H5F.close(fid);
+        end
+
         function testWriteCompoundOverWrite(testCase)
                    
             % Create a temporary HDF5 file

--- a/+tests/+unit/FunctionTests.m
+++ b/+tests/+unit/FunctionTests.m
@@ -19,29 +19,6 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
             testCase.verifyEqual(string(validName), "at_id")
         end
 
-        function testWriteCompoundMap(testCase)
-            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
-            fid = H5F.create('test.h5');
-            data = containers.Map({'a', 'b'}, 1:2);
-            io.writeCompound(fid, '/map_data', data)
-            H5F.close(fid);
-        end
-        function testWriteCompoundEmpty(testCase)
-            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
-            fid = H5F.create('test.h5');
-            data = struct;
-            testCase.verifyError(...
-                @(varargin) io.writeCompound(fid, '/map_data', data), ...
-                'MATLAB:imagesci:hdf5lib:libraryError')
-            H5F.close(fid);
-        end
-        function testWriteCompoundScalar(testCase)
-            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
-            fid = H5F.create('test.h5');
-            data = struct('a','b');
-            io.writeCompound(fid, '/map_data', data)
-            H5F.close(fid);
-        end
         function testIsNeurodatatype(testCase)
             timeSeries = types.core.TimeSeries();
             testCase.verifyTrue(matnwb.utility.isNeurodataType(timeSeries))


### PR DESCRIPTION
## Motivation

Fix compatibility issue in io.writeCompound for MATLAB R2019b and earlier

## How to test the behavior?
Run `tests.unit.io.WriteTest/testWriteCompoundScalar` in MATLAB R2019b
Please note that this test was found here prior to this update: `tests.unit.FunctionsTest/testWriteCompoundScalar`

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
