### PR TITLE
Fix parsing of quantity specification value

### DIFF
--- a/+file/+interface/HasQuantity.m
+++ b/+file/+interface/HasQuantity.m
@@ -1,0 +1,84 @@
+classdef HasQuantity
+% HasQuantity - Provide methods for parsing quantity specification value
+    
+    % properties
+    %     QuantityKey = 'quantity'
+    % end
+    
+    methods (Static, Access = protected)
+        function isRequired = isRequired(source)
+            if isKey(source, 'quantity')
+                quantity = source('quantity');
+                file.interface.HasQuantity.validateQuantity(quantity)
+
+                if ischar(quantity)
+                    switch quantity
+                        case {'?', 'zero_or_one'}
+                            isRequired = false;
+                        case {'*', 'zero_or_many'}
+                            isRequired = false;
+                        case {'+', 'one_or_many'}
+                            isRequired = true;
+                    end
+                elseif isnumeric(quantity)
+                    isRequired = quantity >= 1;
+                end
+            else
+                isRequired = true; % Default
+            end
+        end
+
+        function isScalar = isScalar(source)
+            if isKey(source, 'quantity')
+                quantity = source('quantity');
+                file.interface.HasQuantity.validateQuantity(quantity)
+
+                if ischar(quantity)
+                    switch quantity
+                        case {'?', 'zero_or_one'}
+                            isScalar = true;
+                        case {'*', 'zero_or_many'}
+                            isScalar = false;
+                        case {'+', 'one_or_many'}
+                            isScalar = false;
+                    end
+                elseif isnumeric(quantity)
+                    if quantity == 1
+                        isScalar = true;
+                    end
+                end
+            else
+                isScalar = true; % Default
+            end
+        end
+    end
+
+    methods (Static, Access = private)
+        function validateQuantity(quantity)
+        % validateQuantity - Validate quantity specification value 
+            if ischar(quantity)
+                validQuantities = [ ...
+                    "?", "zero_or_one", ...
+                    "*", "zero_or_many", ...
+                    "+", "one_or_many" ...
+                    ];
+                if ~any(strcmp(validQuantities, quantity))
+                    validQuantitiesStr = strjoin("  " + validQuantities, newline);
+                    ME = MException('NWB:Schema:UnsupportedQuantity', ...
+                        ['Quantity is "%s", but expected quantity to be one of the ' ...
+                        'following values:\n%s\n'], quantity, validQuantitiesStr);
+                    throwAsCaller(ME)
+                end
+
+            elseif isnumeric(quantity)
+                assert( mod(quantity,1) == 0 && quantity > 0, ...
+                    'NWB:Schema:UnsupportedQuantity', ...
+                    'Expected quantity to positive integer')
+            else
+                ME = MException('NWB:Schema:UnsupportedQuantity', ...
+                    'Expected quantity to be text or numeric.');
+                throwAsCaller(ME)
+            end
+        end
+    end
+end

--- a/+file/+interface/HasQuantity.m
+++ b/+file/+interface/HasQuantity.m
@@ -45,6 +45,8 @@ classdef HasQuantity
                 elseif isnumeric(quantity)
                     if quantity == 1
                         isScalar = true;
+                    else
+                        isScalar = false;
                     end
                 end
             else

--- a/+file/Dataset.m
+++ b/+file/Dataset.m
@@ -1,4 +1,4 @@
-classdef Dataset < file.interface.HasProps
+classdef Dataset < file.interface.HasProps & file.interface.HasQuantity
     properties
         name;
         doc;
@@ -79,18 +79,8 @@ classdef Dataset < file.interface.HasProps
             end
             
             if isKey(source, 'quantity')
-                quantity = source('quantity');
-                switch quantity
-                    case '?'
-                        obj.required = false;
-                        obj.scalar = true;
-                    case '*'
-                        obj.required = false;
-                        obj.scalar = false;
-                    case '+'
-                        obj.required = true;
-                        obj.scalar = false;
-                end
+                obj.required = obj.isRequired(source);
+                obj.scalar = obj.isScalar(source);
             end
             
             obj.isConstrainedSet = ~isempty(obj.type) && ~obj.scalar;

--- a/+file/Group.m
+++ b/+file/Group.m
@@ -135,10 +135,6 @@ classdef Group < file.interface.HasProps & file.interface.HasQuantity
             %typed + constrained
             %should never happen
 
-            if strcmp(obj.type, 'NWBFile')
-                %keyboard
-            end
-
             if obj.isConstrainedSet && ~obj.definesType
                 error('NWB:Group:UnsupportedOperation', ...
                       'The method `getProps` should not be called on a constrained dataset.');
@@ -254,7 +250,6 @@ classdef Group < file.interface.HasProps & file.interface.HasQuantity
                     end
                 end
             end
-
         end
     end
 end

--- a/+file/Group.m
+++ b/+file/Group.m
@@ -1,4 +1,4 @@
-classdef Group < file.interface.HasProps
+classdef Group < file.interface.HasProps & file.interface.HasQuantity
     properties
         doc;
         name;
@@ -65,18 +65,8 @@ classdef Group < file.interface.HasProps
             end
             
             if isKey(source, 'quantity')
-                quantity = source('quantity');
-                switch quantity
-                    case '?'
-                        obj.required = false;
-                        obj.scalar = true;
-                    case '*'
-                        obj.required = false;
-                        obj.scalar = false;
-                    case '+'
-                        obj.required = true;
-                        obj.scalar = false;
-                end
+                obj.required = obj.isRequired(source);
+                obj.scalar = obj.isScalar(source);
             end
             
             obj.isConstrainedSet = ~obj.scalar && ~isempty(obj.type);
@@ -144,7 +134,11 @@ classdef Group < file.interface.HasProps
             PropertyMap = containers.Map;
             %typed + constrained
             %should never happen
-            
+
+            if strcmp(obj.type, 'NWBFile')
+                %keyboard
+            end
+
             if obj.isConstrainedSet && ~obj.definesType
                 error('NWB:Group:UnsupportedOperation', ...
                       'The method `getProps` should not be called on a constrained dataset.');

--- a/+file/Link.m
+++ b/+file/Link.m
@@ -1,4 +1,4 @@
-classdef Link
+classdef Link < file.interface.HasQuantity
     properties (SetAccess = private)
         doc;
         name;
@@ -19,12 +19,7 @@ classdef Link
             obj.doc = source('doc');
             obj.name = source('name');
             obj.type = source('target_type');
-            
-            quantityKey = 'quantity';
-            if isKey(source, quantityKey)
-                quantity = source(quantityKey);
-                obj.required = strcmp(quantity, '+');
-            end
+            obj.required = obj.isRequired(source);
         end
     end
 end

--- a/+tests/+unit/+schema/QuantityTest.m
+++ b/+tests/+unit/+schema/QuantityTest.m
@@ -29,5 +29,31 @@ classdef QuantityTest < tests.unit.abstract.SchemaTest
             actualOptionalProperties = string(setdiff(allProperties, actualRequiredProperties));
             testCase.verifyEqual(actualOptionalProperties, expectedOptionalProperties)
         end
+
+        function testInvalidTextQuantitySpecification(testCase)
+            % Simulate a dataset specification with an invalid quantity value
+            specMap = containers.Map('quantity', 'none');
+            testCase.verifyError(...
+                @() file.Dataset(specMap), ...
+                'NWB:Schema:UnsupportedQuantity')
+        end
+
+        function testInvalidNumericQuantitySpecification(testCase)
+            % Simulate a dataset specification with an invalid numeric quantity value
+            specMap = containers.Map('quantity', 1.5);
+
+            testCase.verifyError(...
+                @() file.Dataset(specMap), ...
+                'NWB:Schema:UnsupportedQuantity')
+        end
+               
+        function testInvalidArrayQuantitySpecification(testCase)
+            % Simulate a dataset specification with an invalid numeric quantity value
+            specMap = containers.Map('quantity', {{'*', '+'}});
+
+            testCase.verifyError(...
+                @() file.Dataset(specMap), ...
+                'NWB:Schema:UnsupportedQuantity')
+        end
     end
 end

--- a/+tests/+unit/+schema/QuantityTest.m
+++ b/+tests/+unit/+schema/QuantityTest.m
@@ -1,0 +1,33 @@
+classdef QuantityTest < tests.unit.abstract.SchemaTest
+
+    properties (Constant)
+        SchemaFolder = "quantitySchema"
+        SchemaNamespaceFileName = "quantity.namespace.yaml"
+    end
+
+    methods (Test)
+        function testValidQuantitySpecifications(testCase)
+            quantContainer = types.quantity.QuantityContainer();
+
+            expectedRequiredProperties = [ ...
+                "data_required_array", ...
+                "data_required_array_long_form", ...
+                "data_required_array_short_form", ...
+                "data_required_scalar" ...
+            ];
+            expectedOptionalProperties = [ ...
+                "data_optional_array_long_form", ...
+                "data_optional_array_short_form", ...
+                "data_optional_scalar_long_form", ...
+                "data_optional_scalar_short_form"
+            ];
+
+            actualRequiredProperties = string(quantContainer.getRequiredProperties());
+            testCase.verifyEqual(actualRequiredProperties, expectedRequiredProperties)
+
+            allProperties = properties(quantContainer)';
+            actualOptionalProperties = string(setdiff(allProperties, actualRequiredProperties));
+            testCase.verifyEqual(actualOptionalProperties, expectedOptionalProperties)
+        end
+    end
+end

--- a/+tests/test-schema/quantitySchema/quantity.namespace.yaml
+++ b/+tests/test-schema/quantitySchema/quantity.namespace.yaml
@@ -1,0 +1,7 @@
+namespaces:
+- full_name: Quantity specification values test
+  name: quantity
+  schema:
+  - namespace: core
+  - source: quantity.quantities.yaml
+  version: 1.0.0

--- a/+tests/test-schema/quantitySchema/quantity.quantities.yaml
+++ b/+tests/test-schema/quantitySchema/quantity.quantities.yaml
@@ -1,0 +1,44 @@
+groups:
+- neurodata_type_def: QuantityContainer
+  neurodata_type_inc: NWBDataInterface
+  datasets:
+    - name: data_optional_scalar_short_form
+      dtype: double
+      quantity: '?'
+      shape:
+      - null
+    - name: data_optional_scalar_long_form
+      dtype: double
+      quantity: 'zero_or_one'
+      shape:
+      - null
+    - name: data_optional_array_short_form
+      dtype: double
+      quantity: '*'
+      shape:
+      - null
+    - name: data_optional_array_long_form
+      dtype: double
+      quantity: 'zero_or_many'
+      shape:
+      - null
+    - name: data_required_array_short_form
+      dtype: double
+      quantity: '+'
+      shape:
+      - null
+    - name: data_required_array_long_form
+      dtype: double
+      quantity: 'one_or_many'
+      shape:
+      - null
+    - name: data_required_scalar
+      dtype: double
+      quantity: 1
+      shape:
+      - null
+    - name: data_required_array
+      dtype: double
+      quantity: 2
+      shape:
+      - null

--- a/+types/+untyped/MetaClass.m
+++ b/+types/+untyped/MetaClass.m
@@ -140,6 +140,32 @@ classdef MetaClass < handle & matlab.mixin.CustomDisplay
             warning(warningId, warningMessage) %#ok<SPWRN>
         end
     end
+    
+    methods (Hidden)
+        % Set of methods that should be publicly available, for example for
+        % testing purposes, or other use cases where type inspection might
+        % be necessary.
+        function requiredProps = getRequiredProperties(obj)
+
+            % Introspectively retrieve required properties and add to
+            % persistent cache/map.
+
+            typeClassName = class(obj);
+            typeNamespaceVersion = getNamespaceVersionForType(typeClassName);
+
+            typeKey = sprintf('%s_%s', typeClassName, typeNamespaceVersion);
+
+            if isKey(obj.REQUIRED, typeKey)
+                requiredProps = obj.REQUIRED( typeKey );
+            else
+                mc = metaclass(obj);
+                propertyDescription = {mc.PropertyList.Description};
+                isRequired = startsWith(propertyDescription, 'REQUIRED');
+                requiredProps = {mc.PropertyList(isRequired).Name};
+                obj.REQUIRED( typeKey ) = requiredProps;
+            end
+        end
+    end
 
     methods (Access = protected) % Override matlab.mixin.CustomDisplay
         function str = getFooter(obj)
@@ -229,27 +255,6 @@ classdef MetaClass < handle & matlab.mixin.CustomDisplay
     end
 
     methods (Access = private)
-        function requiredProps = getRequiredProperties(obj)
-
-            % Introspectively retrieve required properties and add to
-            % persistent cache/map.
-
-            typeClassName = class(obj);
-            typeNamespaceVersion = getNamespaceVersionForType(typeClassName);
-
-            typeKey = sprintf('%s_%s', typeClassName, typeNamespaceVersion);
-
-            if isKey(obj.REQUIRED, typeKey)
-                requiredProps = obj.REQUIRED( typeKey );
-            else
-                mc = metaclass(obj);
-                propertyDescription = {mc.PropertyList.Description};
-                isRequired = startsWith(propertyDescription, 'REQUIRED');
-                requiredProps = {mc.PropertyList(isRequired).Name};
-                obj.REQUIRED( typeKey ) = requiredProps;
-            end
-        end
-
         function tf = propertyValueEqualsDefaultValue(obj, propName)
         % propertyValueEqualsDefaultValue - Check if value of property is
         % equal to the property's default value


### PR DESCRIPTION
## Motivation

The NWB specification language [supports multiple value options](https://schema-language.readthedocs.io/en/latest/description.html#quantity) for specifying the quantity of Groups, Datasets and Links, but currently MatNWB will only parse the following quantity values: `*`, `+`, `?`. In other words, it does not support specifying exact quantities as numeric values, or the full text options (`zero_or_many`, `one_or_many`, `zero_or_one`)

This PR adds cases for parsing all possible allowed values as well as error handling if the quantity specifier is invalid.

Changes in this PR:
- Add a class `file.interface.HasQuantity` that can be mixed in with specification types that has a `quantity` specifier
- Add `file.interface.HasQuantity` as superclass to `Group`, `Dataset` and `Link` specification types
- Add a test specification schema and a unit test for testing that quantity specification values are correctly determining if a datatype property should be required or not.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
