### PR TITLE
Add release workflow

### DIFF
--- a/+tests/+unit/+file/CloneNwbTest.m
+++ b/+tests/+unit/+file/CloneNwbTest.m
@@ -40,6 +40,9 @@ end
 
 function restoreNwbFileClass(classDefStr)
     fid = fopen( fullfile(misc.getMatnwbDir(), 'NwbFile.m'), 'wt' );
+    if ispc % Ad hoc fix when saving to file using fwrite on pc
+        classDefStr = strrep(classDefStr, newline, '');
+    end
     fwrite(fid, classDefStr);
     fclose(fid);
 end

--- a/+tests/requirements.txt
+++ b/+tests/requirements.txt
@@ -1,4 +1,6 @@
-hdf5plugin
 scipy
+matplotlib
+hdf5plugin
+dataframe_image
 git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@dev
 git+https://github.com/NeurodataWithoutBorders/pynwb.git@dev

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -120,12 +120,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: test-results-*
-          merge-multiple: true
+          merge-multiple: false
 
       - name: Publish test results
         uses: mikepenz/action-junit-report@v4
         with:
-          report_paths: 'testResults.xml'
+          report_paths: '*/testResults.xml'
 
   update_version:
     name: Create new draft relase for given version

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -132,8 +132,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run_tests]
     steps:
-      - name: Check out repository
+      - name: Checkout repository using deploy key
         uses: actions/checkout@v4
+        with:
+          ref: refs/heads/main
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Update Contents.m file
         run: |

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,223 @@
+# Run MATLAB tests across multiple MATLAB versions and create a draft release
+
+name: Prepare release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number in major.minor.patch format, i.e 2.8.0'
+        required: true
+        type: string
+
+jobs:
+  validate_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check version format
+        run: |
+          version="${{ github.event.inputs.version }}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Input for 'version' ('$version') is not in the expected major.minor.patch format."
+            exit 1
+          fi
+          echo "Version '$version' is valid."
+
+  run_tests:
+    name: Run MATLAB tests (${{ matrix.matlab-version }})
+    runs-on: ubuntu-latest
+    needs: [validate_version]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - matlab-version: R2021a
+            python-version: '3.9'
+            skip-pynwb-compatibilty-test-for-tutorial: '1'
+          - matlab-version: R2021b
+            python-version: '3.9'
+            skip-pynwb-compatibilty-test-for-tutorial: '1'
+          - matlab-version: R2022a
+            python-version: '3.9'
+            skip-pynwb-compatibilty-test-for-tutorial: '0'
+          - matlab-version: R2022b
+            python-version: '3.9'
+            skip-pynwb-compatibilty-test-for-tutorial: '0'
+          - matlab-version: R2023a
+            python-version: '3.10'
+            skip-pynwb-compatibilty-test-for-tutorial: '0'
+          - matlab-version: R2023b
+            python-version: '3.10'
+            skip-pynwb-compatibilty-test-for-tutorial: '0'
+          - matlab-version: R2024a
+            python-version: '3.11'
+            skip-pynwb-compatibilty-test-for-tutorial: '0'
+          - matlab-version: R2024b
+            python-version: '3.11'
+            skip-pynwb-compatibilty-test-for-tutorial: '0'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Configure python env
+        run: |
+          python -m pip install -U pip
+          pip install -r +tests/requirements.txt
+          python -m pip list
+          echo "HDF5_PLUGIN_PATH=$(python -c "import hdf5plugin; print(hdf5plugin.PLUGINS_PATH)")" >> "$GITHUB_ENV"
+          echo $( python -m pip show nwbinspector | grep ^Location: | awk '{print $2}' )
+
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: ${{ matrix.matlab-version }}
+
+      - name: Run tests
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            setenv("SKIP_PYNWB_COMPATIBILITY_TEST_FOR_TUTORIALS", ...
+                num2str(${{ matrix.skip-pynwb-compatibilty-test-for-tutorial }}))
+            pyenv("ExecutionMode", "OutOfProcess");
+            results = assertSuccess(nwbtest('ReportOutputFolder', '.')); 
+            assert(~isempty(results), 'No tests ran');
+
+      - name: Upload JUnit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.matlab-version }}
+          path: testResults.xml
+
+  publish_junit:
+    name: Publish JUnit test results
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [run_tests]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve result files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-results-*
+          merge-multiple: true
+
+      - name: Publish test results
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: 'testResults*.xml'
+
+  update_version:
+    name: Create new draft relase for given version
+    runs-on: ubuntu-latest
+    needs: [run_tests]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Update Contents.m file
+        run: |
+          # Read the template file
+          template=$(cat .github/workflows/templates/contents_header_template.txt)
+          
+          # Get current date in DD-MMM-YYYY format
+          date_string=$(date +"%d-%b-%Y")
+          
+          # Get current year
+          year_number=$(date +"%Y")
+          
+          # Replace placeholders in template
+          header="${template/\{\{version_number\}\}/${{ github.event.inputs.version }}}"
+          header="${header/\{\{date_string\}\}/$date_string}"
+          header="${header/\{\{year_number\}\}/$year_number}"
+          
+          # Extract the content after the header from the current Contents.m file
+          content=$(awk '/^% -{10,}/{flag=1;next} flag{print}' Contents.m)
+          
+          # Combine new header with existing content
+          echo "$header" > Contents.m
+          echo "$content" >> Contents.m
+
+      - name: Commit updated Contents.m file
+        continue-on-error: true
+        run: |
+          git config user.name "${{ github.workflow }} by ${{ github.actor }}"
+          git config user.email "<>"
+          git add Contents.m
+          git commit -m "Update version number in Contents.m"
+          git fetch
+          git push
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12' # Pinned to 3.12 because of pybadges dependencies
+
+      - name: Generate tested with badge
+        run: |
+          pip install --upgrade setuptools
+          pip install pybadges
+          mkdir -p .github/badges/v${{ inputs.version }}
+          python -c "
+          from pybadges import badge
+          with open('.github/badges/v${{ inputs.version }}/tested_with.svg', 'w') as f:
+              f.write(badge(
+                  left_text='tested with',
+                  right_text='R2021a | R2021b | R2022a | R2022b | R2023a | R2023b | R20204 | R2024b',
+                  right_color='green'
+              ))
+          "
+
+      - name: Tag repository with version tag
+        if: always()
+        run: |
+          git fetch
+
+          git config user.name "${{ github.workflow }} by ${{ github.actor }}"
+          git config user.email "<>"
+
+          # Recreate the tag with a message
+          git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}" 
+
+          # Push the new tag to the remote repository
+          git push origin "${{ inputs.version }}"
+      
+      # Commit the SVG for the MATLAB releases test badge to gh-badges branch
+      - name: Checkout gh-badges branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-badges
+          path: gh-badges
+
+      - name: Push to gh-badges
+        run: |
+          mkdir -p gh-badges/.github/badges/v${{ inputs.version }}
+          cp .github/badges/v${{ inputs.version }}/tested_with.svg gh-badges/.github/badges/v${{ inputs.version }}/tested_with.svg
+          cd gh-badges
+
+          git config user.name "${{ github.workflow }} by ${{ github.actor }}"
+          git config user.email "<>"
+
+          # Only proceed with commit and push if changes are detected
+          if [[ $(git add .github/badges/* --dry-run | wc -l) -gt 0 ]]; then
+            git add .github/badges/*
+            git commit -m "Update 'tested_with' badge for release v${{ inputs.version }}"
+            git push -f
+          else
+            echo "Nothing to commit"
+          fi
+
+      # Create the release
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          tag: ${{ inputs.version }}
+          generateReleaseNotes: true
+          body: "![MATLAB Versions Tested](https://raw.githubusercontent.com/NeurodataWithoutBorders/matnwb/refs/heads/gh-badges/.github/badges/v${{ inputs.version }}/tested_with.svg)"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-13]
         matlab-version: [R2021a, R2021b, R2022a, R2022b, R2023a, R2023b, R2024a, R2024b]
         include:
           - matlab-version: R2021a
@@ -65,13 +65,23 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure python env
+      - name: Install python dependencies
         run: |
           python -m pip install -U pip
           pip install -r +tests/requirements.txt
           python -m pip list
+
+      - name: Configure python env (macOS, ubuntu)
+        if: runner.os != 'Windows'
+        run: |
           echo "HDF5_PLUGIN_PATH=$(python -c "import hdf5plugin; print(hdf5plugin.PLUGINS_PATH)")" >> "$GITHUB_ENV"
-          echo $( python -m pip show nwbinspector | grep ^Location: | awk '{print $2}' )
+
+      - name: Configure python env (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $pluginPath = python -c "import hdf5plugin; print(hdf5plugin.PLUGINS_PATH)"
+          Add-Content -Path $env:GITHUB_ENV -Value "HDF5_PLUGIN_PATH=$pluginPath"
 
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
@@ -80,6 +90,8 @@ jobs:
 
       - name: Run tests
         uses: matlab-actions/run-command@v2
+        env:
+          HDF5_PLUGIN_PATH: ${{ env.HDF5_PLUGIN_PATH }}
         with:
           command: |
             setenv("SKIP_PYNWB_COMPATIBILITY_TEST_FOR_TUTORIALS", ...
@@ -92,7 +104,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.matlab-version }}
+          name: test-results-${{ matrix.os }}-${{ matrix.matlab-version }}
           path: testResults.xml
 
   publish_junit:
@@ -113,7 +125,7 @@ jobs:
       - name: Publish test results
         uses: mikepenz/action-junit-report@v4
         with:
-          report_paths: 'testResults*.xml'
+          report_paths: 'testResults.xml'
 
   update_version:
     name: Create new draft relase for given version
@@ -184,7 +196,7 @@ jobs:
           git config user.name "${{ github.workflow }} by ${{ github.actor }}"
           git config user.email "<>"
 
-          # Recreate the tag with a message
+          # Create the tag with a message
           git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}" 
 
           # Push the new tag to the remote repository
@@ -222,4 +234,6 @@ jobs:
           draft: true
           tag: ${{ inputs.version }}
           generateReleaseNotes: true
-          body: "![MATLAB Versions Tested](https://raw.githubusercontent.com/NeurodataWithoutBorders/matnwb/refs/heads/gh-badges/.github/badges/v${{ inputs.version }}/tested_with.svg)"
+          body: |
+            ![Tested On Platforms](https://raw.githubusercontent.com/NeurodataWithoutBorders/matnwb/refs/heads/gh-badges/.github/badges/tested_on.svg)
+            ![MATLAB Versions Tested](https://raw.githubusercontent.com/NeurodataWithoutBorders/matnwb/refs/heads/gh-badges/.github/badges/v${{ inputs.version }}/tested_with.svg)

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -24,11 +24,13 @@ jobs:
 
   run_tests:
     name: Run MATLAB tests (${{ matrix.matlab-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: [validate_version]
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        matlab-version: [R2021a, R2021b, R2022a, R2022b, R2023a, R2023b, R2024a, R2024b]
         include:
           - matlab-version: R2021a
             python-version: '3.9'
@@ -169,7 +171,7 @@ jobs:
           with open('.github/badges/v${{ inputs.version }}/tested_with.svg', 'w') as f:
               f.write(badge(
                   left_text='tested with',
-                  right_text='R2021a | R2021b | R2022a | R2022b | R2023a | R2023b | R20204 | R2024b',
+                  right_text='R2021a | R2021b | R2022a | R2022b | R2023a | R2023b | R2024 | R2024b',
                   right_color='green'
               ))
           "

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Version '$version' is valid."
 
   run_tests:
-    name: Run MATLAB tests (${{ matrix.matlab-version }})
+    name: Run MATLAB tests (${{ matrix.matlab-version }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: [validate_version]
     strategy:

--- a/.github/workflows/templates/contents_header_template.txt
+++ b/.github/workflows/templates/contents_header_template.txt
@@ -1,0 +1,5 @@
+% MatNWB : NWB For MATLAB
+% Version {{version_number}} (R2019b+) {{date_string}}
+%
+% Copyright (c) {{year_number}}, Neurodata Without Borders
+% ---------------------------------------------

--- a/Contents.m
+++ b/Contents.m
@@ -1,0 +1,27 @@
+% MatNWB : NWB For MATLAB
+% Version 2.7.0 (R2019b+) 19-Nov-2024
+%
+% Copyright (c) 2024, Neurodata Without Borders
+% ---------------------------------------------
+%
+% Functions:
+% 
+%             NwbFile - Root object representing an NWB file.
+%        generateCore - Generate Matlab classes from NWB core schema files
+%   generateExtension - Generate Matlab classes from NWB extension schema file
+%      inspectNwbFile - Run nwbinspector on the specified NWB file
+%   nwbClearGenerated - Clear generated class files.
+%           nwbExport - Writes an NWB file.
+% nwbInstallExtension - Installs a specified NWB extension.
+%             nwbRead - Read an NWB file.
+%             nwbtest - Run MatNWB test suite.
+%
+% Namespaces:
+%              types - Namespace containing classes for neurodata types.
+%               util - Namespace containing utility functions.
+%
+% Folders:
+%
+%          tutorials - Livescript tutorials demonstrating how to work with MatNWB
+%         namespaces - Cached namespace specifications
+%         nwb-schema - Source NWB specification schemas for different NWB versions

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,3 +39,5 @@ Contents
 
    pages/developer/contributing
    pages/developer/documentation
+   pages/developer/releases
+

--- a/docs/source/pages/developer/releases.rst
+++ b/docs/source/pages/developer/releases.rst
@@ -3,7 +3,7 @@
 How to Create a New Release
 ===========================
 
-1. **Navigate to the `"Actions" <https://github.com/NeurodataWithoutBorders/matnwb/actions/workflows/prepare_release.yml>`_ tab** in the MatNwb repository on GitHub.
+1. **Navigate to the** `"Actions" <https://github.com/NeurodataWithoutBorders/matnwb/actions/workflows/prepare_release.yml>`_ **tab** in the MatNwb repository on GitHub.
 
 2. **Click "Run workflow"**, then:
    - Enter the desired version number in ``major.minor.patch`` format (e.g., ``2.8.0``).

--- a/docs/source/pages/developer/releases.rst
+++ b/docs/source/pages/developer/releases.rst
@@ -1,0 +1,20 @@
+.. _how-to-create-release:
+
+How to Create a New Release
+===========================
+
+1. **Navigate to the `"Actions" <https://github.com/NeurodataWithoutBorders/matnwb/actions/workflows/prepare_release.yml>`_ tab** in the MatNwb repository on GitHub.
+
+2. **Click "Run workflow"**, then:
+   - Enter the desired version number in ``major.minor.patch`` format (e.g., ``2.8.0``).
+   - Click the **Run workflow** button to start the process.
+
+3. **Monitor the workflow** as it runs across multiple MATLAB and OS configurations. The workflow is successful if:
+   - The version string is valid.
+   - All tests pass successfully.
+
+4. **Confirm the draft release** once the workflow completes:
+   - A new tag (matching your version number) is pushed to the repository.
+   - A draft release is automatically generated with updated badges and the revised ``Contents.m`` file.
+
+5. **(Optional) Finalize the release** by editing the draft release in GitHub’s "Releases" section, adding any additional details, and clicking **"Publish release"**.


### PR DESCRIPTION
## Motivation

Create a workflow to use for preparing new releases.
The workflow is triggered via workflow_dispatch, so it can be run from the [Actions](https://github.com/NeurodataWithoutBorders/matnwb/actions) page. It requires a version number as an input and will run the following jobs/steps
- Matrix testing across all available MATLAB releases on ubuntu-latest, windows-latest and macos-13
- Publish test results

If tests succeed:
- It will update the version number in a newly added `Contents.m` file and push back to the main branch
- Create a tested_with badge that will be pushed to the gh-badges branch
- Create a new draft release using the version number as a tag.

## How to test the behavior?
```
Run the workflow
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
