### PR TITLE
Control concurrency to only allow one workflow run per PR branch

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,6 +12,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_tests:
     name: Run MATLAB tests (${{ matrix.matlab-version }})


### PR DESCRIPTION
## Motivation
Automatically cancel a (previous) test workflow run if new commits are pushed to a branch before the previous run has completed

## How to test the behavior?
N/A

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
