### PR TITLE
Fix bug automatic datapipe configuration

### DIFF
--- a/+io/+config/+internal/configureDataPipeFromData.m
+++ b/+io/+config/+internal/configureDataPipeFromData.m
@@ -5,7 +5,13 @@ function dataPipe = configureDataPipeFromData(numericData, datasetConfig)
     import types.untyped.datapipe.properties.DynamicFilter
 
     chunkSize = computeChunkSizeFromConfig(numericData, datasetConfig.chunking);
-    maxSize = size(numericData);
+    if isvector(numericData)
+        % If input data is vector, we use maxSize = Inf to enforce a 1D
+        % columnar representation of data in file.
+        maxSize = Inf;
+    else
+        maxSize = size(numericData);
+    end
 
     dataPipeArgs = {...
         "data", numericData, ...


### PR DESCRIPTION
## Motivation

This change fixes a failing test in PR #716.

**In summary:**
When applying a dataset configuration (PR #636), the DataPipe's `maxSize` was previously set automatically in the `DataPipe` constructor. Using that default behavior, vectors were mapped onto 2D datasets in file, because the `maxSize` was set to **[Inf, n]**, respecting the 2D nature of MATLAB vectors. This change forces a vector to 1D by explicitly setting `maxSize` to **[Inf]** when creating a `DataPipe` for column- and row-vectors.

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
