### PR TITLE
Fix parsing for hard and external link types in `io.parseGroup`

### DIFF
--- a/+io/+internal/+h5/isValidLinkType.m
+++ b/+io/+internal/+h5/isValidLinkType.m
@@ -1,0 +1,4 @@
+function tf = isValidLinkType(linkType)
+    VALID_TYPES = {'soft link', 'hard link', 'external link'};
+    tf = any(strcmp(linkType, VALID_TYPES));
+end

--- a/+io/parseGroup.m
+++ b/+io/parseGroup.m
@@ -43,16 +43,16 @@ end
 linkProperties = containers.Map;
 for i=1:length(info.Links)
     link = info.Links(i);
+    fullPath = [info.Name '/' link.Name];
+    assert( io.internal.h5.isValidLinkType(link.Type), ...
+        'NWB:ParseGroup:UnsupportedLinkType', ...
+        ['An unsupported link type ("%s") is present at the location: %s. ', ...
+        'Please report!'], link.Type, fullPath)
     switch link.Type
         case {'soft link', 'hard link'}
             lnk = types.untyped.SoftLink(link.Value{1});
         case 'external link'
             lnk = types.untyped.ExternalLink(link.Value{:});
-        otherwise
-            fullPath = [info.Name '/' link.Name];
-            error('NWB:ParseGroup:UnsupportedLinkType', ...
-                ['An unsupported link type ("%s") is present at the ', ...
-                'location: %s. Please report!'], link.Type, fullPath)
     end
     linkProperties(link.Name) = lnk;
 end

--- a/+io/parseGroup.m
+++ b/+io/parseGroup.m
@@ -44,10 +44,15 @@ linkProperties = containers.Map;
 for i=1:length(info.Links)
     link = info.Links(i);
     switch link.Type
-        case 'soft link'
+        case {'soft link', 'hard link'}
             lnk = types.untyped.SoftLink(link.Value{1});
-        otherwise %todo assuming external link here
+        case 'external link'
             lnk = types.untyped.ExternalLink(link.Value{:});
+        otherwise
+            fullPath = [info.Name '/' link.Name];
+            error('NWB:ParseGroup:UnsupportedLinkType', ...
+                ['An unsupported link type ("%s") is present at the ', ...
+                'location: %s. Please report!'], link.Type, fullPath)
     end
     linkProperties(link.Name) = lnk;
 end

--- a/+tests/+unit/linkTest.m
+++ b/+tests/+unit/linkTest.m
@@ -50,7 +50,7 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
             fileName = 'external_link_export_import.nwb';
             nwbExport(nwb, fileName)
             
-            nwbIn = nwbRead(fileName);
+            nwbIn = nwbRead(fileName, 'ignorecache');
             tsIn = nwbIn.acquisition.get('timeseries_with_external_data');
             testCase.assertClass(tsIn.data, 'types.untyped.ExternalLink')
         end
@@ -156,7 +156,7 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
                 'Hard link should appear as a group reference' )
             
             % Read the file back with nwbRead and verify it works
-            nwbReadResult = nwbRead(fileName);
+            nwbReadResult = nwbRead(fileName, 'ignorecache');
             testCase.verifyClass(nwbReadResult, 'NwbFile', ...
                 'Should be able to read the file as an NWB file');
             

--- a/+tests/+unit/linkTest.m
+++ b/+tests/+unit/linkTest.m
@@ -14,7 +14,7 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
             testCase.verifyEqual(l.path, '/mypath');
             testCase.verifyEqual(l.filename, 'myfile.nwb');
         end
-        
+
         function testSoftLinkConstructor(testCase)
             l = types.untyped.SoftLink('/mypath');
             testCase.verifyEqual(l.path, '/mypath');
@@ -42,6 +42,19 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
             testCase.verifyEqual(info.Links.Value, {'extern.nwb';'/mypath'});
         end
         
+        function testExternalLinkExportImport(testCase)
+            nwb = tests.factory.NWBFile();
+            ts = tests.factory.TimeSeriesWithTimestamps();
+            ts.data = types.untyped.ExternalLink('myfile.nwb', '/mypath');
+            nwb.acquisition.set('timeseries_with_external_data', ts);
+            fileName = 'external_link_export_import.nwb';
+            nwbExport(nwb, fileName)
+            
+            nwbIn = nwbRead(fileName);
+            tsIn = nwbIn.acquisition.get('timeseries_with_external_data');
+            testCase.assertClass(tsIn.data, 'types.untyped.ExternalLink')
+        end
+
         function testSoftResolution(testCase)
             nwb = NwbFile;
             dev = types.core.Device;
@@ -106,5 +119,80 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
             testCase.verifyError(@createElectrodeGroupWithWrongDeviceType, ...
                 'NWB:CheckDType:InvalidNeurodataType')
         end
+        
+        function testHardLinkCreationAndRead(testCase)
+            % Test creating a hard link by converting a soft link using low-level H5 functions
+            fileName = 'test_hardlink.nwb';
+            
+            % Create NWB file with a device and electrode group using soft link
+            nwb = tests.factory.NWBFile();
+            dev = types.core.Device('description', 'device for hard link test');
+            nwb.general_devices.set('testDevice', dev);
+            nwb.general_extracellular_ephys.set('testEphys',...
+                types.core.ElectrodeGroup(...
+                    'device', types.untyped.SoftLink(dev), ...
+                    'description', 'test with hard link', ...
+                    'location', 'n/a') ...
+            );
+            
+            % Export the NWB file
+            nwbExport(nwb, fileName);
+            
+            % Use helper method to replace the soft link with a hard link
+            softLinkPath = '/general/extracellular_ephys/testEphys/device';
+            targetPath = '/general/devices/testDevice';
+            testCase.replaceSoftLinkWithHardLink(fileName, softLinkPath, targetPath)
+
+            % Verify the hard link was created correctly using h5info
+            fileInfoAfter = h5info(fileName, "/general"); 
+            isEphysGroup = strcmp({fileInfoAfter.Groups.Name}, '/general/extracellular_ephys');
+            ephysInfo = fileInfoAfter.Groups(isEphysGroup);
+            testCase.verifyTrue( strcmp(ephysInfo.Groups.Links.Type, 'hard link') )
+
+            % Verify it behaves like a hard link by reading it directly 
+            % (it should appear as a group, not a link);
+            info = h5info(fileName, '/general/extracellular_ephys/testEphys');
+            testCase.verifyTrue( endsWith(info.Groups.Name, 'device'), ...
+                'Hard link should appear as a group reference' )
+            
+            % Read the file back with nwbRead and verify it works
+            nwbReadResult = nwbRead(fileName);
+            testCase.verifyClass(nwbReadResult, 'NwbFile', ...
+                'Should be able to read the file as an NWB file');
+            
+            % Verify the electrode group is still accessible
+            readEphys = nwbReadResult.general_extracellular_ephys.get('testEphys');
+            testCase.verifyClass(readEphys, 'types.core.ElectrodeGroup', ...
+                'ElectrodeGroup should be readable');
+            
+            % Verify the device reference still works (hard link should be transparent)
+            readDevice = readEphys.device;
+            testCase.verifyClass(readDevice, 'types.untyped.SoftLink', ...
+                'Hard links will be treated using SoftLink type')
+            
+            % Verify it can be dereferenced
+            actualDevice = readDevice.deref(nwbReadResult);
+            testCase.verifyClass(actualDevice, 'types.core.Device', ...
+                'Device should be accessible through hard link');
+        end
+    end
+
+    methods (Static, Access=private)
+        function replaceSoftLinkWithHardLink(fileName, softLinkPath, targetPath)
+            % Use low-level H5 functions to replace a soft link with a hard link
+            fid = H5F.open(fileName, 'H5F_ACC_RDWR', 'H5P_DEFAULT');
+            closeFile = onCleanup(@()H5F.close(fid));
+            
+            % Delete the existing soft link
+            H5L.delete(fid, softLinkPath, 'H5P_DEFAULT');
+            
+            % Create a hard link to replace it
+            H5L.create_hard(fid, targetPath, fid, softLinkPath, ...
+                'H5P_DEFAULT', 'H5P_DEFAULT');
+            
+            % Close the file
+            clear closeFile;
+        end
     end
 end
+


### PR DESCRIPTION
Fix #735 

## Motivation

Fix bug where a HDF5 link of type "hard link" was treated as an "external link". 

## How to test the behavior?
``` matlab
 runtests('tests.unit.linkTest/testHardLinkCreationAndRead')
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
