### PR TITLE
Refactor DataStub for better cloud performance

### DIFF
--- a/+io/parseDataset.m
+++ b/+io/parseDataset.m
@@ -65,7 +65,8 @@ function parsed = parseDataset(filename, info, fullpath, Blacklist)
         elseif any(dataspace.Size == 0)
             data = [];
         else
-            data = types.untyped.DataStub(filename, fullpath);
+            matlabDataType = datatypeInfoToMatlabType(datatype);
+            data = types.untyped.DataStub(filename, fullpath, dataspace.Size, matlabDataType);
         end
         H5T.close(tid);
         H5P.close(pid);
@@ -82,4 +83,23 @@ function parsed = parseDataset(filename, info, fullpath, Blacklist)
     end
     H5D.close(did);
     H5F.close(fid);
+end
+
+function matlabDataType = datatypeInfoToMatlabType(datatype)
+    if ischar(datatype.Type)
+        matlabDataType = io.getMatType(datatype.Type);
+
+    elseif isstruct(datatype.Type)
+        if strcmp(datatype.Class, 'H5T_STRING')
+            if strcmp(datatype.Type.Length, 'H5T_VARIABLE') && ...
+                  strcmp(datatype.Type.CharacterSet, 'H5T_CSET_UTF8') && ...
+                  strcmp(datatype.Type.CharacterType, 'H5T_C_S1')
+                matlabDataType = 'char';
+            else
+                keyboard
+            end
+        else
+            keyboard
+        end
+    end
 end


### PR DESCRIPTION
## Motivation

The current implementation of `types.untyped.DataStub` will repeatedly call H5 functions to resolve datasize and type. 
These should be immutable for the whole lifetime of a DataStub, and should only be accessed from file once. This will improve perfomance, especially when reading files from a cloud location.

## Changes in this PR
- Add private properties (`dims_` and `dataType_`) for internally storing values for dependent props `dims` and `dataType` 
- Add option to set `dims` and `dataType` on construction
- Pass dims and dataType info to DataStub constructor in io.parseDataset as this information is available from the `h5info` structure

## Questions to resolve
- Why did these dependent properties not have internal backing before? Are they ever expected to change?

## Todo

- [ ] Function that can determine MATLAB data type from a `h5info` **DataType** structure

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
