### PR TITLE
[CI] Update tag format in release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -230,10 +230,10 @@ jobs:
           git config user.email "<>"
 
           # Create the tag with a message
-          git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}" 
+          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}" 
 
           # Push the new tag to the remote repository
-          git push origin "${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
       
       # Commit the SVG for the MATLAB releases test badge to gh-badges branch
       - name: Checkout gh-badges branch


### PR DESCRIPTION
Fix tag format to follow recommendation of prefixing release tags with **v**, like **v2.10.0**

## Motivation
Fix the tag format of tags autogenerated by the `prepare-release` workflow

## How to test the behavior?
N/A

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
