### PR TITLE
Fix namespace bug for hdmf-experimental types

### DIFF
--- a/+io/getNeurodataTypeInfo.m
+++ b/+io/getNeurodataTypeInfo.m
@@ -48,5 +48,32 @@ function typeInfo = getNeurodataTypeInfo(attributeInfo)
     if hasTypeDef && hasNamespace
         typeInfo.typename = matnwb.common.composeFullClassName(...
             typeInfo.namespace, typeInfo.name);
+
+        if strcmp(typeInfo.namespace, 'hdmf-experimental') && ~exist(typeInfo.typename, 'class')
+            typeInfo = correctNamespaceIfShouldBeHdmfCommon(typeInfo);
+        end 
+    end
+end
+
+function typeInfo = correctNamespaceIfShouldBeHdmfCommon(typeInfo)
+% correctNamespaceIfShouldBeHdmfCommon - Correct namespace if value in file is wrong.
+%
+% This function provides a workaround for a bug where the namespace of a 
+% neurodata type was wrongly written to file as hdmf-experimental instead
+% of hdmf-common.
+% 
+% If the namespace of a type is hdmf-experimental, and the corresponding type 
+% class does not exist in MATLAB, but the equivalent hdmf_common class exists, 
+% the namespace is changed from hdmf-experimental to hdmf-common.
+%
+% The bug is described in this issue: 
+% https://github.com/hdmf-dev/hdmf/issues/1347#issuecomment-3662210800
+
+    if strcmp(typeInfo.namespace, 'hdmf-experimental') && ~exist(typeInfo.typename, 'class')
+        correctedTypename = replace(typeInfo.typename, 'hdmf_experimental', 'hdmf_common');
+        if exist(correctedTypename, 'class') == 8
+            typeInfo.typename = correctedTypename;
+            typeInfo.namespace = 'hdmf-common';
+        end
     end
 end

--- a/+io/getNeurodataTypeInfo.m
+++ b/+io/getNeurodataTypeInfo.m
@@ -67,7 +67,7 @@ function typeInfo = correctNamespaceIfShouldBeHdmfCommon(typeInfo)
 % the namespace is changed from hdmf-experimental to hdmf-common.
 %
 % The bug is described in this issue: 
-% https://github.com/hdmf-dev/hdmf/issues/1347#issuecomment-3662210800
+% https://github.com/hdmf-dev/hdmf/issues/1347
 
     if strcmp(typeInfo.namespace, 'hdmf-experimental') && ~exist(typeInfo.typename, 'class')
         correctedTypename = replace(typeInfo.typename, 'hdmf_experimental', 'hdmf_common');

--- a/+io/getNeurodataTypeInfo.m
+++ b/+io/getNeurodataTypeInfo.m
@@ -46,8 +46,8 @@ function typeInfo = getNeurodataTypeInfo(attributeInfo)
     
     % Get full classname given a namespace and a neurodata type
     if hasTypeDef && hasNamespace
-        typeInfo.typename = matnwb.common.composeFullClassName(...
-            typeInfo.namespace, typeInfo.name);
+        typeInfo.typename = char( matnwb.common.composeFullClassName(...
+            typeInfo.namespace, typeInfo.name) );
 
         if strcmp(typeInfo.namespace, 'hdmf-experimental') && ~exist(typeInfo.typename, 'class')
             typeInfo = correctNamespaceIfShouldBeHdmfCommon(typeInfo);

--- a/+tests/+unit/+io/GetNeurodataTypeInfoTest.m
+++ b/+tests/+unit/+io/GetNeurodataTypeInfoTest.m
@@ -1,0 +1,141 @@
+classdef GetNeurodataTypeInfoTest < matlab.unittest.TestCase
+% GetNeurodataTypeInfoTest - Unit tests for io.getNeurodataTypeInfo function.
+
+    properties (TestParameter)
+        HDMFCommonType = {'DynamicTable', 'VectorData', 'VectorIndex'}
+    end
+
+    methods (Test)
+        function testEmptyInput(testCase)
+            % Test that empty input returns empty typeInfo
+            typeInfo = io.getNeurodataTypeInfo([]);
+            
+            testCase.verifyEqual(typeInfo.namespace, '');
+            testCase.verifyEqual(typeInfo.name, '');
+            testCase.verifyEqual(typeInfo.typename, '');
+        end
+        
+        function testValidNeurodataType(testCase)
+            % Test with valid neurodata type and namespace
+            attributeInfo = struct(...
+                'Name', {'neurodata_type', 'namespace'}, ...
+                'Value', {'DynamicTable', 'hdmf-common'});
+            
+            typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+            
+            testCase.verifyEqual(typeInfo.namespace, 'hdmf-common');
+            testCase.verifyEqual(typeInfo.name, 'DynamicTable');
+            testCase.verifyEqual(typeInfo.typename, 'types.hdmf_common.DynamicTable');
+        end
+        
+        function testOnlyNeurodataType(testCase)
+            % Test with only neurodata_type attribute (no namespace)
+            attributeInfo = struct(...
+                'Name', {'neurodata_type'}, ...
+                'Value', {'DynamicTable'});
+            
+            typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+            
+            testCase.verifyEqual(typeInfo.namespace, '');
+            testCase.verifyEqual(typeInfo.name, 'DynamicTable');
+            testCase.verifyEqual(typeInfo.typename, '');
+        end
+        
+        function testOnlyNamespace(testCase)
+            % Test with only namespace attribute (no neurodata_type)
+            attributeInfo = struct(...
+                'Name', {'namespace'}, ...
+                'Value', {'hdmf-common'});
+            
+            typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+            
+            testCase.verifyEqual(typeInfo.namespace, 'hdmf-common');
+            testCase.verifyEqual(typeInfo.name, '');
+            testCase.verifyEqual(typeInfo.typename, '');
+        end
+        
+        function testHdmfExperimentalFallbackToHdmfCommon(testCase, HDMFCommonType)
+            % Test fallback correction for VectorData with incorrect 
+            % hdmf-experimental namespace (should be hdmf-common)
+            attributeInfo = struct(...
+                'Name', {'neurodata_type', 'namespace'}, ...
+                'Value', {HDMFCommonType, 'hdmf-experimental'});
+            
+            typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+            
+            % Should be corrected to hdmf-common
+            testCase.verifyEqual(typeInfo.namespace, 'hdmf-common');
+            testCase.verifyEqual(typeInfo.name, HDMFCommonType);
+            testCase.verifyEqual(typeInfo.typename, sprintf('types.hdmf_common.%s', HDMFCommonType));
+        end
+        
+        function testCellStringValueHandling(testCase)
+            % Test that cell string values are handled correctly
+            attributeInfo = struct(...
+                'Name', {'neurodata_type', 'namespace'}, ...
+                'Value', {{'DynamicTable'}, {'hdmf-common'}});
+            
+            typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+            
+            testCase.verifyEqual(typeInfo.namespace, 'hdmf-common');
+            testCase.verifyEqual(typeInfo.name, 'DynamicTable');
+            testCase.verifyEqual(typeInfo.typename, 'types.hdmf_common.DynamicTable');
+        end
+        
+        function testNoFallbackForValidHdmfExperimentalType(testCase)
+            % Test that valid hdmf-experimental types are not incorrectly 
+            % changed to hdmf-common
+            %
+            % Note: This test verifies that if a type genuinely belongs to
+            % hdmf-experimental and exists there, it should not be changed.
+            % EnumData is an example type that exists only in 
+            % hdmf-experimental.
+            
+            % First, check if types.hdmf_experimental exists and has types
+            if exist('types.hdmf_experimental.EnumData', 'class') == 8
+                attributeInfo = struct(...
+                    'Name', {'neurodata_type', 'namespace'}, ...
+                    'Value', {'EnumData', 'hdmf-experimental'});
+                
+                typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+                
+                % Should remain hdmf-experimental since the class exists there
+                testCase.verifyEqual(typeInfo.namespace, 'hdmf-experimental');
+                testCase.verifyEqual(typeInfo.typename, 'types.hdmf_experimental.EnumData');
+            else
+                % If hdmf-experimental types don't exist, skip this test
+                testCase.assumeTrue(false, ...
+                    'Skipping test: types.hdmf_experimental.EnumData class not found');
+            end
+        end
+        
+        function testNoFallbackForNonExistentType(testCase)
+            % Test that non-existent types in hdmf-experimental that also 
+            % don't exist in hdmf-common remain unchanged (the typename 
+            % will still point to hdmf-experimental since no fallback exists)
+            attributeInfo = struct(...
+                'Name', {'neurodata_type', 'namespace'}, ...
+                'Value', {'NonExistentType', 'hdmf-experimental'});
+            
+            typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+            
+            % Should remain hdmf-experimental since there's no hdmf-common fallback
+            testCase.verifyEqual(typeInfo.namespace, 'hdmf-experimental');
+            testCase.verifyEqual(typeInfo.name, 'NonExistentType');
+            testCase.verifyEqual(typeInfo.typename, 'types.hdmf_experimental.NonExistentType');
+        end
+        
+        function testCoreNamespaceUnchanged(testCase)
+            % Test that core namespace types are not affected by fallback logic
+            attributeInfo = struct(...
+                'Name', {'neurodata_type', 'namespace'}, ...
+                'Value', {'NWBFile', 'core'});
+            
+            typeInfo = io.getNeurodataTypeInfo(attributeInfo);
+            
+            testCase.verifyEqual(typeInfo.namespace, 'core');
+            testCase.verifyEqual(typeInfo.name, 'NWBFile');
+            testCase.verifyEqual(typeInfo.typename, 'types.core.NWBFile');
+        end
+    end
+end


### PR DESCRIPTION
Adds a workaround for a bug where neurodata types are incorrectly assigned the 'hdmf-experimental' namespace instead of 'hdmf-common'. If a MATLAB class does not exist for 'hdmf-experimental' but does for 'hdmf-common', the namespace and typename are corrected accordingly on read

See [hdmf-dev/hdmf#1347](https://github.com/hdmf-dev/hdmf/issues/1347) for details.

## Motivation

Support read for files affected by the issue described above

## How to test the behavior?
N/A

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
