### PR TITLE
Update listExtensions.m

### DIFF
--- a/+matnwb/+extension/listExtensions.m
+++ b/+matnwb/+extension/listExtensions.m
@@ -39,7 +39,8 @@ function extensionTable = listExtensions(options)
         catalogUrl = "https://raw.githubusercontent.com/nwb-extensions/nwb-extensions.github.io/refs/heads/main/data/records.json";
         extensionRecords = jsondecode(webread(catalogUrl));
         extensionRecords = consolidateStruct(extensionRecords);
-                    
+        extensionRecords = removeUnnamedExtensions(extensionRecords);
+        
         extensionRecords = struct2table(extensionRecords);
 
         fieldsKeep = ["name", "version", "last_updated", "src", "license", "maintainers", "readme"];
@@ -80,4 +81,15 @@ function structArray = consolidateStruct(S)
             structArray(i).(missingFields{j}) = [];
         end
     end
+end
+
+function extensionRecords = removeUnnamedExtensions(extensionRecords)
+    % Only keep extensions that have a name
+    keep = false(1, numel(extensionRecords));
+    for i = 1:numel(extensionRecords)
+        if ~isempty(extensionRecords(i).name)
+            keep(i) = true;
+        end
+    end
+    extensionRecords = extensionRecords(keep);
 end


### PR DESCRIPTION
## Motivation

Add filter to ignore extensions without a name when retrieving metadata for all published ndx-extensions.

**Background:**
An empty repository was created for a staged extension in the [nwb-extensions](https://github.com/nwb-extensions) organization. This added the following entry to the [nwb-extension records](https://github.com/nwb-extensions/nwb-extensions.github.io/blob/8a501064783c0a12aa086b1d8bce8b6797aa8961/data/records.json#L1):

```json
{
    "ndx_fscv_record": {
        "ref": "ndx-fscv-record",
        "record_url": "https://github.com/nwb-extensions/ndx-fscv-record",
        "last_updated": "2026-01-07T16:55:57Z"
     }
}
```

This repository uses that records file to create a list of extensions, but the code failed when an extension without required metadata is present. This PR fixes that by ignoring entries in the records file which does not have a name.




## How to test the behavior?
Running this command should work
```
matnwb.extension.listExtensions()
```

Currently (2026-01-13) this command fails on `main` due to the state of the ndx-extensions organization.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
