### PR TITLE
[Bugfix] Fix raw/primitive dtype validation

### DIFF
--- a/+tests/+unit/+types/+validators/CheckDtypeTest.m
+++ b/+tests/+unit/+types/+validators/CheckDtypeTest.m
@@ -110,6 +110,19 @@ classdef CheckDtypeTest < matlab.unittest.TestCase
                 'NWB:CheckDataType:InvalidConversion')
         end
 
+        function testRejectsDatasetClassWhenRawDataIsExpected(testCase)
+            vectorData = types.hdmf_common.VectorData(...
+                'data', int8(1), ...
+                'description', 'test');
+
+            testCase.verifyError(...
+                @() types.util.checkDtype('data', 'numeric', vectorData), ...
+                'NWB:CheckDataType:InvalidConversion')
+            testCase.verifyError(...
+                @() types.core.Image('data', vectorData), ...
+                'NWB:CheckDataType:InvalidConversion')
+        end
+
 
 
     end

--- a/+types/+util/checkDtype.m
+++ b/+types/+util/checkDtype.m
@@ -32,11 +32,6 @@ function value = checkDtype(name, typeDescriptor, value)
             % Softlinks cannot be validated at this level.
         end
     
-    elseif isValueContainedInHDMFDatasetType(typeDescriptor, value) 
-        % If the value is itself a dataset class, we need to unpack and 
-        % validate its contained data property.
-        value.data = types.util.checkDtype(name, typeDescriptor, value.data);
-    
     elseif isempty(value) % Handle empty values
         % For certain types (numeric, logical, char), we replace [] with a typed 
         % empty value.
@@ -105,13 +100,6 @@ function mustBeValidTypeDescriptor(typeDescriptor)
     assert( isValid, ...
         'NWB:CheckDataType:InvalidTypeDescriptor', ...
         'Type descriptor must be a struct, character vector or a string.');
-end
-
-function tf = isValueContainedInHDMFDatasetType(typeDescriptor, value)
-    tf = ~isempty(value) ...
-        && ~matnwb.utility.isNeurodataType(typeDescriptor) ...
-        && isa(value, 'types.untyped.DatasetClass') ...
-        && isprop(value, 'data');
 end
 
 function value = checkDtypeForCompoundDataset(name, typeDescriptor, value)


### PR DESCRIPTION
## Motivation

`types.util.checkDtype` previously had a special case for `DatasetClass` values (e.g. `VectorData`) with a `.data` property. That meant raw dtype validators such as `types.util.checkDtype('data', 'numeric', value)` could silently accept a nested dataset object, validate its contained `.data`, and keep the outer dataset object in place.

That behavior was a bug for properties like `Image.data`, which expect raw dataset payloads rather than nested dataset objects. For example, this could succeed during construction even though the value was invalid:

```matlab
vectorData = types.hdmf_common.VectorData(...
    'data', int8(1), ...
    'description', 'test');

img = types.core.Image('data', vectorData);
```

The resulting object kept `vectorData` as `img.data`, and export later failed because nested dataset objects are not a supported raw dataset value.

This code snippet was introduced in [PR#740](https://github.com/NeurodataWithoutBorders/matnwb/pull/740), but the reason is unclear.

This PR removes that special case so raw/primitive dtype validation does not allow `VectorData` (or similar) types.

## How to test the behavior?
```matlab
vectorData = types.hdmf_common.VectorData(...
    'data', int8(1), ...
    'description', 'test');

types.core.Image('data', vectorData)
```

**Before**
 This succeeded even though Image.data expects raw numeric data.
 
**After**
```matlab
Error using types.util.checkDtype (line 64)
Error setting property 'data' because value cannot be converted to 'numeric'.

Error in types.core.Image/validate_data (line 57)
        val = types.util.checkDtype('data', 'numeric', val);
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in types.hdmf_common.Data/set.data (line 48)
        obj.data = obj.validate_data(val);
                   ^^^^^^^^^^^^^^^^^^^^^^
Error in types.hdmf_common.Data (line 37)
        obj.data = p.Results.data;
        ^^^^^^^^
Error in types.core.NWBData (line 24)
        obj = obj@types.hdmf_common.Data(varargin{:});
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in types.core.BaseImage (line 30)
        obj = obj@types.core.NWBData(varargin{:});
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error in types.core.Image (line 32)
        obj = obj@types.core.BaseImage(varargin{:});
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Caused by:
    Error using assert
    Value of type `types.hdmf_common.VectorData` cannot be converted to type `numeric`:
      value is not instance of type numeric. Got type types.hdmf_common.VectorData instead
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
