### PR TITLE
[CI] Update versions for CI actions to most recent versions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,15 +26,15 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           cache: true
 
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -76,10 +76,10 @@ jobs:
             skip-nwbinspector-test: '0'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -110,12 +110,12 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "HDF5_PLUGIN_PATH=$pluginPath"
 
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: ${{ matrix.matlab-version }}
 
       - name: Run tests
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         env:
           HDF5_PLUGIN_PATH: ${{ env.HDF5_PLUGIN_PATH }}
         with:
@@ -142,7 +142,7 @@ jobs:
     needs: [run_tests]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Retrieve result files
         uses: actions/download-artifact@v4
@@ -161,7 +161,7 @@ jobs:
     needs: [run_tests]
     steps:
       - name: Checkout repository using deploy key
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/heads/main
           ssh-key: ${{ secrets.DEPLOY_KEY }}
@@ -200,7 +200,7 @@ jobs:
           git push
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12' # Pinned to 3.12 because of pybadges dependencies
 
@@ -240,7 +240,7 @@ jobs:
       
       # Commit the SVG for the MATLAB releases test badge to gh-badges branch
       - name: Checkout gh-badges branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-badges
           path: gh-badges

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.matlab-version }}
           path: testResults.xml
@@ -145,13 +145,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Retrieve result files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: test-results-*
           merge-multiple: false
 
       - name: Publish test results
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         with:
           report_paths: '*/testResults.xml'
 

--- a/.github/workflows/run_codespell.yml
+++ b/.github/workflows/run_codespell.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract codespell configurations from configuration file
         id: config

--- a/.github/workflows/run_pynwb_dev_tests.yml
+++ b/.github/workflows/run_pynwb_dev_tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set latest MATLAB and Python versions
         id: set-versions
@@ -25,7 +25,7 @@ jobs:
           echo "python_version=$latest_python_version" >> $GITHUB_OUTPUT
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ steps.set-versions.outputs.python_version }}
 
@@ -39,7 +39,7 @@ jobs:
           echo "HDF5_PLUGIN_PATH=$(python -c "import hdf5plugin; print(hdf5plugin.PLUGINS_PATH)")" >> "$GITHUB_ENV"
 
       - name: Check out PyNWB dev repository  (for testing PyNWB tutorials)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: NeurodataWithoutBorders/pynwb
           ref: dev
@@ -49,12 +49,12 @@ jobs:
         run: echo "PYNWB_REPO_DIR=$GITHUB_WORKSPACE/pynwb-repo" >> "$GITHUB_ENV"
 
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: ${{ steps.set-versions.outputs.matlab_version }}
 
       - name: Run PyNWB-dependent tests
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: |
             setenv("SKIP_PYNWB_TESTS", "0")

--- a/.github/workflows/run_pynwb_dev_tests.yml
+++ b/.github/workflows/run_pynwb_dev_tests.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pynwb-dev-test-results
           path: testResults.xml

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,7 +39,7 @@ jobs:
       latest_matlab_version: ${{ steps.set-matrix.outputs.latest_matlab_version }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set matrix
         id: set-matrix
@@ -87,10 +87,10 @@ jobs:
       matrix: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -113,7 +113,7 @@ jobs:
 
       - name: Check out PyNWB repository (for testing PyNWB tutorials)
         if: ${{ matrix.skip-pynwb-tests == '0' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: NeurodataWithoutBorders/pynwb
           ref: ${{ steps.configure-python.outputs.pynwb_version }}
@@ -124,14 +124,14 @@ jobs:
         run: echo "PYNWB_REPO_DIR=$GITHUB_WORKSPACE/pynwb-repo" >> "$GITHUB_ENV"
 
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         if: always()
         with:
           release: ${{ matrix.matlab-version }}
           cache: ${{ env.USE_CACHE }}
 
       - name: Run tests
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: |
             setenv("SKIP_PYNWB_TESTS", ...
@@ -164,7 +164,7 @@ jobs:
     needs: [run_tests]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Retrieve result files
         uses: actions/download-artifact@v4
@@ -184,7 +184,7 @@ jobs:
     needs: [run_tests, set_matrix]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Retrieve code coverage files
         uses: actions/download-artifact@v4
@@ -192,7 +192,7 @@ jobs:
           name: test-coverage-${{ needs.set_matrix.outputs.latest_matlab_version }}
 
       - name: Publish on coverage results on Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage*.xml

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.matlab-version }}
           path: testResults.xml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload coverage results
         if: always() && matrix.matlab-version == needs.set_matrix.outputs.latest_matlab_version
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-coverage-${{ matrix.matlab-version }}
           path: ./coverage.xml
@@ -167,13 +167,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Retrieve result files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: test-results-*
           merge-multiple: true
 
       - name: Publish test results
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         with:
           report_paths: 'testResults*.xml'
 
@@ -187,7 +187,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Retrieve code coverage files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-coverage-${{ needs.set_matrix.outputs.latest_matlab_version }}
 

--- a/.github/workflows/update_extension_list.yml
+++ b/.github/workflows/update_extension_list.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
       
       # Use deploy key to push back to protected branch
       - name: Checkout repository using deploy key
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/heads/main
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Update extension list in nwbInstallExtensions
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: |
             addpath(genpath("tools"));


### PR DESCRIPTION
## Motivation

Update versions for actions used in Github Actions workflows due to this deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4, matlab-actions/run-command@v2, matlab-actions/setup-matlab@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.



## How to test the behavior?
CI should run with errors or warnings

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
