### PR TITLE
fix: add missing .py extension in PyNWB tutorial skip list

### DIFF
--- a/+tests/+system/+tutorial/PynwbTutorialTest.m
+++ b/+tests/+system/+tutorial/PynwbTutorialTest.m
@@ -21,7 +21,7 @@ classdef (SharedTestFixtures = {tests.fixtures.SetEnvironmentVariableFixture}) .
             'streaming.py', ...             % Requires that HDF5 library is installed with the ROS3 driver enabled which is not a given
             'object_id.py', ...             % Does not export nwb file
             'plot_configurator.py', ...     % Does not export nwb file
-            'plot_zarr_io', ...             % Does not export nwb file in nwb format
+            'plot_zarr_io.py', ...          % Does not export nwb file in nwb format
             'brain_observatory.py', ...     % Requires allen sdk
             'extensions.py'};               % Discrepancy between tutorial and schema: https://github.com/NeurodataWithoutBorders/pynwb/issues/1952
 


### PR DESCRIPTION
## Summary
MatNWB runs PyNWB tutorials as part of testing/CI and the intention was to ignore `plot_zarr_io` via the `SkippedTutorials` list of `tests.system.tutorial.PynwbTutorialTest`. However, the `plot_zarr_io` element was missing the `.py` extension. The skip matcher uses exact-string `ismember` against `dir` listing names (which include the extension), so the entry never matched and the tutorial ran on every CI build.

The tutorial requires `numcodecs`, which was previously installed via nwbinspector. Following [nwbinspector:PR#699](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/699) `numcodecs` is not installed anymore, so CI now fails with `ModuleNotFoundError: No module named 'numcodecs'` when the tutorial is executed.

## Change

[`+tests/+system/+tutorial/PynwbTutorialTest.m:24`](+tests/+system/+tutorial/PynwbTutorialTest.m#L24) — `'plot_zarr_io'` → `'plot_zarr_io.py'`. Brings the entry in line with every other tutorial in the list and matches the actual gallery filename.

## How to test

```matlab
runtests('tests.system.tutorial.PynwbTutorialTest')
```

The `plot_zarr_io.py` parameterised test variant should now be filtered out at suite construction time.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?