### PR TITLE
Allow export of DynamicTable without columns

### DIFF
--- a/+tests/+unit/dynamicTableTest.m
+++ b/+tests/+unit/dynamicTableTest.m
@@ -502,6 +502,29 @@ classdef dynamicTableTest < tests.abstract.NwbTestCase
             testCase.verifyError(@() nwbExport(nwb, fileName), ...
                 'NWB:CustomConstraintUnfulfilled');
         end
+
+        function testExportTableWithoutColumns(testCase)
+            % A DynamicTable that genuinely has no columns (e.g. an
+            % IntracellularRecordingsTable whose data lives entirely in its
+            % category sub-tables) has empty `colnames` by definition and must
+            % still be exportable without adding a dummy column.
+            fileName = testCase.getRandomFilename();
+            nwb = tests.factory.NWBFile();
+
+            dynamicTable = types.hdmf_common.DynamicTable( ...
+                'description', 'table without any columns', ...
+                'id', types.hdmf_common.ElementIdentifiers('data', (0:2)'));
+            testCase.verifyEmpty(dynamicTable.colnames);
+
+            nwb.acquisition.set('DynamicTable', dynamicTable);
+
+            testCase.verifyWarningFree(@() nwbExport(nwb, fileName));
+
+            readNwb = nwbRead(fileName, 'ignorecache');
+            readTable = readNwb.acquisition.get('DynamicTable');
+            testCase.verifyEmpty(readTable.colnames);
+            testCase.verifyEqual(readTable.id.data.load(), int64((0:2)'));
+        end
     end
 
     methods (Static, Access=private)

--- a/+types/+untyped/MetaClass.m
+++ b/+types/+untyped/MetaClass.m
@@ -237,6 +237,19 @@ classdef MetaClass < handle & matlab.mixin.CustomDisplay
 
         function throwErrorIfMissingRequiredProps(obj, fullpath)
             missingRequiredProps = obj.checkRequiredProps();
+
+            % Exception: `colnames` of a DynamicTable is only required to
+            % order existing columns. A DynamicTable that genuinely has no
+            % columns (e.g. an empty IntracellularRecordingsTable) has empty
+            % `colnames` by definition and must still be exportable.
+            % `checkConfig` runs first via throwErrorIfCustomConstraintUnfulfilled
+            % (see the comment in `export`) and already errors when columns
+            % exist without being listed in `colnames`. Reaching this point with
+            % empty `colnames` therefore guarantees the table has no columns.
+            if isa(obj, 'types.hdmf_common.DynamicTable')
+                missingRequiredProps = setdiff(missingRequiredProps, 'colnames', 'stable');
+            end
+
             if ~isempty( missingRequiredProps )
                 propertyListStr = obj.prettyPrintPropertyList(missingRequiredProps);
                 error('NWB:RequiredPropertyMissing', ...


### PR DESCRIPTION
## Motivation

A DynamicTable that has no required columns (e.g. an `IntracellularRecordingsTable` whose data lives entirely in its category sub-tables) has empty `colnames` by default. However, `colnames` is a required attribute according to the hdmf-schema and therefore the required-property guard in `MetaClass.export` flagged the empty `colnames` as missing, forcing users to add a dummy column to export. See also [nwb-schema#692](https://github.com/NeurodataWithoutBorders/nwb-schema/issues/692).

In that issue I proposed to change the schema, but I decided to add this fix independently to MatNWB to mimic the existing behaviour in PyNWB.

This PR exempts `colnames` from the missing-required-property error for DynamicTables. This is safe because `checkConfig` runs first (via `throwErrorIfCustomConstraintUnfulfilled`) and already errors when columns exist without being listed in `colnames`, so reaching this point with empty `colnames` guarantees the table has no columns.

## How to test the behavior?
```
runtests('tests.unit.dynamicTableTest/testExportTableWithoutColumns')
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
