### PR TITLE
[CI] Fix failing tests after PyNWB v4.0.0 release

### DIFF
--- a/+tests/+system/+tutorial/PynwbTutorialTest.m
+++ b/+tests/+system/+tutorial/PynwbTutorialTest.m
@@ -23,6 +23,7 @@ classdef (SharedTestFixtures = {tests.fixtures.SetEnvironmentVariableFixture}) .
             'plot_configurator.py', ...     % Does not export nwb file
             'plot_zarr_io.py', ...          % Does not export nwb file in nwb format
             'brain_observatory.py', ...     % Requires allen sdk
+            'resources_streaming.py', ...   % Requires dandi api
             'extensions.py'};               % Discrepancy between tutorial and schema: https://github.com/NeurodataWithoutBorders/pynwb/issues/1952
 
         % SkippedFiles - Name of exported nwb files to skip reading with matnwb

--- a/+tests/+system/PyNWBIOTest.py
+++ b/+tests/+system/PyNWBIOTest.py
@@ -205,7 +205,7 @@ class NWBFileIOTest(PyNWBIOTest):
                         'SIunit', timestamps=list(range(10)), resolution=0.1)
         self.file.add_acquisition(ts)
         mod = file.create_processing_module('test_module', 'a test module')
-        mod.add_container(SpatialSeries("SpatialSeries", list(range(1, 11)),
+        mod.add(SpatialSeries("SpatialSeries", list(range(1, 11)),
                                     description='A test spatial series',
                                     unit='n/a',
                                     timestamps=list(range(1, 11))))

--- a/+tests/+system/UnitTimesIOTest.m
+++ b/+tests/+system/UnitTimesIOTest.m
@@ -47,7 +47,7 @@ classdef UnitTimesIOTest < tests.system.PyNWBIOTest
             file.units.waveform_sd_sampling_rate = 1;
 
             % Skip waveforms_sampling_rate because PyNWB does not export it.
-            % Units.waveforms_sampling_rate = 1
+            file.units.waveforms_sampling_rate = 1;
         end
         
         function c = getContainer(~, file)


### PR DESCRIPTION
## Motivation

Several tests that rely on PyNWB started breaking after PyNWB v4.0.0 was released. This PR is for fixing these test errors

Failure points / todos
- [x] ignore new `resources_streaming.py` PyNWB tutorial when testing the PyNWB tutorials as it depends on dandy api
- [x] Use `add` instead of the removed `add_container` method in PyNWB IO test 
- [ ] Add workaround (property alias) for the new `events` property of NWBFile fix on PR #794 
- [x] tests.system.UnitTimesIOTest/testInFromPyNWB - waveforms_sampling_rate is not equal
- [x] OnePhotonSeries generation is broken because docstring is a multiline string and generator does not support that

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
