### PR TITLE
Pin pynwb="3.1.3" for CI test workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -101,7 +101,7 @@ jobs:
           pip install -r +tests/requirements.txt
           # Install pynwb and nwbinspector only for Python 3.10+ (both dropped Python 3.9 support)
           if [[ "${{ matrix.skip-pynwb-tests }}" == "0" ]]; then
-            pip install pynwb
+            pip install "pynwb==3.1.3"
             pynwb_version=$(pip show pynwb | grep "^Version:" | awk '{print $2}')
             echo "pynwb_version=$pynwb_version" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Motivation

Pin PyNWB to 3.1.3 for CI, because PyNWB 4.0.0 introduced breaking changes.

## How to test the behavior?
```
N/A
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
