### PR TITLE
Fix bugs in documentation build

### DIFF
--- a/+file/+internal/processDocstring.m
+++ b/+file/+internal/processDocstring.m
@@ -12,7 +12,11 @@ function docstring = processDocstring(docstring, continuationPrefix)
     end
 
     docstring = strtrim(docstring);
-    lines = strsplit(docstring, newline);
+    % CollapseDelimiters must be false: schema docs can have blank lines
+    % separating paragraphs, and the default (true) silently merges them
+    % away, losing structure the reST docs pipeline depends on to tell
+    % paragraphs/lists apart.
+    lines = strsplit(docstring, newline, 'CollapseDelimiters', false);
     lines = strip(lines, 'right');
     docstring = char(strjoin(lines, [newline char(continuationPrefix)]));
 end

--- a/+file/fillConstructor.m
+++ b/+file/fillConstructor.m
@@ -278,7 +278,7 @@ function docString = fillConstructorDocString(name, props, namespace, superClass
         catch
             description = 'No description';
         end
-        description = file.internal.processDocstring(description, "%   ");
+        description = file.internal.processDocstring(description, "%    ");
 
         docString = [docString, ...
             sprintf("%%  - %s (%s) - %s", propName, valueType, description), ...

--- a/+types/+core/OnePhotonSeries.m
+++ b/+types/+core/OnePhotonSeries.m
@@ -38,31 +38,38 @@ methods
         %  - control_description (char) - Description of each control value. Must be present if control is present. If present, control_description[0] should describe time points where control == 0.
         %
         %  - data (numeric) - Time-series of microscopy data indexed as data[time, width, height].
-        %   Indexing convention:
-        %     - width: first spatial axis (horizontal direction, columns)
-        %     - height: second spatial axis (vertical direction, rows)
-        %   For raster-scanning systems (two-photon, confocal, one-photon laser scanning):
-        %     - width: fast scan direction (horizontal)
-        %     - height: slow scan direction (vertical)
-        %   Coordinate system diagram::
-        %     height  ^
-        %     (slow)  |
-        %             |    +-----------------+
-        %             |    |                 |
-        %             |    |   Image plane   |
-        %             |    |                 |
-        %             |    +-----------------+
-        %             |
-        %             0 ----------------------> width (fast)
-        %   For non-raster systems (wide-field, light-sheet, random-access), width and height
-        %   are arbitrary coordinates of the image plane.
-        %   Note: This indexing convention conflicts with standard matrix[row, column] notation
-        %   for array access where the first index moves vertically through rows and the second moves horizontally
-        %   through columns. In the schema, data[time, width, height] means that the first spatial
-        %   index moves horizontally (width) through columns and the second spatial index moves
-        %   vertically (height) through rows. In summary, incrementing the first spatial index
-        %   moves you horizontally across the image, while in matrix notation it would move you
-        %   vertically across the rows of the image.
+        %    
+        %    Indexing convention:
+        %      - width: first spatial axis (horizontal direction, columns)
+        %      - height: second spatial axis (vertical direction, rows)
+        %    
+        %    For raster-scanning systems (two-photon, confocal, one-photon laser scanning):
+        %      - width: fast scan direction (horizontal)
+        %      - height: slow scan direction (vertical)
+        %    
+        %    Coordinate system diagram::
+        %    
+        %      height  ^
+        %      (slow)  |
+        %              |    +-----------------+
+        %              |    |                 |
+        %              |    |   Image plane   |
+        %              |    |                 |
+        %              |    +-----------------+
+        %              |
+        %              0 ----------------------> width (fast)
+        %    
+        %    
+        %    For non-raster systems (wide-field, light-sheet, random-access), width and height
+        %    are arbitrary coordinates of the image plane.
+        %    
+        %    Note: This indexing convention conflicts with standard matrix[row, column] notation
+        %    for array access where the first index moves vertically through rows and the second moves horizontally
+        %    through columns. In the schema, data[time, width, height] means that the first spatial
+        %    index moves horizontally (width) through columns and the second spatial index moves
+        %    vertically (height) through rows. In summary, incrementing the first spatial index
+        %    moves you horizontally across the image, while in matrix notation it would move you
+        %    vertically across the rows of the image.
         %
         %  - data_continuity (char) - Optionally describe the continuity of the data. Can be "continuous", "instantaneous", or "step". For example, a voltage trace would be "continuous", because samples are recorded from a continuous process. An array of lick times would be "instantaneous", because the data represents distinct moments in time. Times of image presentations would be "step" because the picture remains the same until the next timepoint. This field is optional, but is useful in providing information about the underlying data. It may inform the way this data is interpreted, the way it is visualized, and what analysis methods are applicable. For storing instantaneous event information, it is recommended to use an EventsTable instead of a TimeSeries with continuity set to "instantaneous".
         %

--- a/+types/+core/TwoPhotonSeries.m
+++ b/+types/+core/TwoPhotonSeries.m
@@ -33,29 +33,36 @@ methods
         %  - control_description (char) - Description of each control value. Must be present if control is present. If present, control_description[0] should describe time points where control == 0.
         %
         %  - data (numeric) - Time-series of microscopy data indexed as data[time, width, height].
-        %   Indexing convention:
-        %     - width: first spatial axis (horizontal direction, columns)
-        %     - height: second spatial axis (vertical direction, rows)
-        %   For raster-scanning systems (two-photon, confocal, one-photon laser scanning):
-        %     - width: fast scan direction (horizontal)
-        %     - height: slow scan direction (vertical)
-        %   Coordinate system diagram::
-        %     height  ^
-        %     (slow)  |
-        %             |    +-----------------+
-        %             |    |                 |
-        %             |    |   Image plane   |
-        %             |    |                 |
-        %             |    +-----------------+
-        %             |
-        %             0 ----------------------> width (fast)
-        %   For non-raster systems (wide-field, light-sheet, random-access), width and height
-        %   are arbitrary coordinates of the image plane.
-        %   Note: This indexing convention conflicts with standard matrix[row, column] notation
-        %   for array access where the first index moves vertically through rows and the second moves horizontally
-        %   through columns. In the schema, data[time, width, height] means that the first spatial
-        %   index moves horizontally (width) through columns and the second spatial index moves
-        %   vertically (height) through rows.
+        %    
+        %    Indexing convention:
+        %      - width: first spatial axis (horizontal direction, columns)
+        %      - height: second spatial axis (vertical direction, rows)
+        %    
+        %    For raster-scanning systems (two-photon, confocal, one-photon laser scanning):
+        %      - width: fast scan direction (horizontal)
+        %      - height: slow scan direction (vertical)
+        %    
+        %    Coordinate system diagram::
+        %    
+        %      height  ^
+        %      (slow)  |
+        %              |    +-----------------+
+        %              |    |                 |
+        %              |    |   Image plane   |
+        %              |    |                 |
+        %              |    +-----------------+
+        %              |
+        %              0 ----------------------> width (fast)
+        %    
+        %    
+        %    For non-raster systems (wide-field, light-sheet, random-access), width and height
+        %    are arbitrary coordinates of the image plane.
+        %    
+        %    Note: This indexing convention conflicts with standard matrix[row, column] notation
+        %    for array access where the first index moves vertically through rows and the second moves horizontally
+        %    through columns. In the schema, data[time, width, height] means that the first spatial
+        %    index moves horizontally (width) through columns and the second spatial index moves
+        %    vertically (height) through rows.
         %
         %  - data_continuity (char) - Optionally describe the continuity of the data. Can be "continuous", "instantaneous", or "step". For example, a voltage trace would be "continuous", because samples are recorded from a continuous process. An array of lick times would be "instantaneous", because the data represents distinct moments in time. Times of image presentations would be "step" because the picture remains the same until the next timepoint. This field is optional, but is useful in providing information about the underlying data. It may inform the way this data is interpreted, the way it is visualized, and what analysis methods are applicable. For storing instantaneous event information, it is recommended to use an EventsTable instead of a TimeSeries with continuity set to "instantaneous".
         %

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Remove folders not needed for docs build
+        run: rm -rf +tests tools tutorials
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Remove folders not needed for docs build
-        run: rm -rf +tests tools tutorials
+        run: rm -rf +tests tools tutorials # not part of published API docs; fewer .m files for autodoc to scan
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,47 @@
+name: Build docs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "+**/*.m"
+      - ".github/workflows/build_docs.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "+**/*.m"
+      - ".github/workflows/build_docs.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_docs:
+    name: Build Sphinx docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r docs/requirements.txt
+
+      - name: Apply RTD-equivalent pre-build customizations
+        run: python docs/source/sphinx_extensions/copy_files.py
+
+      - name: Build docs (fail on any warning)
+        run: sphinx-build -b html -W --keep-going docs/source docs/build/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,3 +17,4 @@ python:
 
 sphinx:
   configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
     python: "3.10"
   jobs:
     pre_build:
+      - rm -rf +tests tools tutorials
       - python docs/source/sphinx_extensions/copy_files.py
 
     post_build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.10"
   jobs:
     pre_build:
-      - rm -rf +tests tools tutorials
+      - rm -rf +tests tools tutorials # not part of published API docs; fewer .m files for autodoc to scan
       - python docs/source/sphinx_extensions/copy_files.py
 
     post_build:

--- a/docs/source/pages/concepts/file_read/untyped.rst
+++ b/docs/source/pages/concepts/file_read/untyped.rst
@@ -86,7 +86,7 @@ DataStubs and DataPipes
 When working with NWB files, datasets can be very large (gigabytes or more). Loading all this data into memory at once would be impractical or impossible. MatNWB uses two types to handle on-disk data efficiently: **DataStubs** and **DataPipes**.
 
 DataStubs (Read only)
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 A **DataStub** (``types.untyped.DataStub``) represents a read-only reference to data stored in an NWB file. When you read an NWB file, non-scalar and multi-dimensional datasets are automatically represented as DataStubs rather than loaded into memory.
 
@@ -102,7 +102,7 @@ Key characteristics:
 You'll encounter DataStubs whenever you read existing NWB files containing non-scalar or multi-dimensional datasets.
 
 DataPipes (read and write)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 A **DataPipe** (``types.untyped.DataPipe``) extends the concept of lazy data access to support **writing** as well as reading. While DataStubs are created automatically when reading files, you create DataPipes explicitly when writing data.
 

--- a/docs/source/pages/getting_started/how_to_cite.rst
+++ b/docs/source/pages/getting_started/how_to_cite.rst
@@ -1,5 +1,6 @@
 .. This page is linked to directly (e.g. from overview.rst) but is not part
    of any toctree, so :orphan: suppresses the "not included in toctree" warning.
+
 :orphan:
 
 Citing MatNWB

--- a/docs/source/pages/getting_started/how_to_cite.rst
+++ b/docs/source/pages/getting_started/how_to_cite.rst
@@ -1,3 +1,7 @@
+.. This page is linked to directly (e.g. from overview.rst) but is not part
+   of any toctree, so :orphan: suppresses the "not included in toctree" warning.
+:orphan:
+
 Citing MatNWB
 =============
 

--- a/docs/source/sphinx_extensions/docstring_processors.py
+++ b/docs/source/sphinx_extensions/docstring_processors.py
@@ -1,13 +1,6 @@
 # Patches generated MATLAB docstrings so they parse as valid reST. Fixes
 # rendering only — never change what fillConstructor.m embeds in the
 # generated .m source, since that text also serves plain `help` output.
-#
-# Root cause of the multiline cases: schema `doc:` fields are valid reST as
-# written (nwb-schema's own docs render them fine, unmodified). matnwb's
-# schema parsing drops the blank lines before fillConstructor.m embeds the
-# text, which is what breaks it here. The proper fix is upstream (preserve
-# blank lines/indentation through codegen); this module is a downstream
-# workaround until that happens.
 import os
 import re
 from _util import list_neurodata_types
@@ -22,7 +15,6 @@ def process_matlab_docstring(app, what, name, obj, options, lines):
     _format_input_arguments(lines)
     _split_and_format_example_lines(lines)
     _escape_role_end_before_invalid_char(lines)
-    _wrap_multiline_argument_descriptions(lines)
 
 
 # Characters allowed to directly follow an inline markup end-string in reST.
@@ -47,72 +39,6 @@ def _escape_role_end_before_invalid_char(lines):
 
     for i, line in enumerate(lines):
         lines[i] = _ROLE_END_PATTERN.sub(_insert_escape, line)
-
-
-# Matches the first line of a "- name (type) - description" Name-Value
-# Arguments list item (as produced by file.internal.processDocstring /
-# fillConstructor.m), capturing its leading indentation. Runs after
-# _format_input_arguments, so the name/type may already be wrapped in
-# "**...**" / "``...``" markup.
-_ARG_ITEM_START_PATTERN = re.compile(r"^(?P<indent>\s*)-\s+\*{0,2}\w+\*{0,2}\s*(?:\(.*?\))?\s*-\s*\S")
-
-# Inline markup that earlier formatting passes may have applied to a line;
-# stripped from literal-block content below so diagrams/nested lists are
-# shown as their original plain text rather than with stray markup chars.
-_INLINE_MARKUP_PATTERNS = (
-    re.compile(r":[\w:]+:`([^`<]+?)\s*<[^>]+>`\\?\s*"),
-    re.compile(r":[\w:]+:`([^`]+?)`"),
-    re.compile(r"\*\*(.+?)\*\*"),
-    re.compile(r"``(.+?)``"),
-)
-
-
-def _strip_inline_markup(line):
-    for pattern in _INLINE_MARKUP_PATTERNS:
-        line = pattern.sub(r"\1", line)
-    return line
-
-
-def _wrap_multiline_argument_descriptions(lines):
-    """
-    Some schema descriptions (YAML literal block scalars) span multiple
-    lines and may contain nested bullet lists, ASCII diagrams, or other
-    structured text. By the time it reaches this docstring, that content
-    has already lost the blank lines and relative indentation that made it
-    valid reST in the schema source (see module note above), so it fails
-    to parse here (e.g. a nested list immediately following a paragraph
-    with no blank line). Render the continuation as a reST literal block
-    instead, so it is always displayed verbatim rather than being
-    (mis-)parsed as reST.
-
-    Modifies the `lines` list in place.
-    """
-
-    i = 0
-    while i < len(lines):
-        match = _ARG_ITEM_START_PATTERN.match(lines[i])
-        if not match:
-            i += 1
-            continue
-
-        item_index = i
-        i += 1
-        continuation_start = i
-        while i < len(lines) and lines[i].strip() != "":
-            i += 1
-        continuation = lines[continuation_start:i]
-
-        if not continuation:
-            continue
-
-        literal_indent = match.group("indent") + "    "
-        literal_lines = [literal_indent + _strip_inline_markup(cline) for cline in continuation]
-
-        lines[item_index] += "::"
-        lines[continuation_start:i] = [""] + literal_lines
-        i = continuation_start + len(literal_lines) + 1
-
-    return lines
 
 
 def _format_matlab_type_as_code_literal(lines):

--- a/docs/source/sphinx_extensions/docstring_processors.py
+++ b/docs/source/sphinx_extensions/docstring_processors.py
@@ -1,3 +1,13 @@
+# Patches generated MATLAB docstrings so they parse as valid reST. Fixes
+# rendering only — never change what fillConstructor.m embeds in the
+# generated .m source, since that text also serves plain `help` output.
+#
+# Root cause of the multiline cases: schema `doc:` fields are valid reST as
+# written (nwb-schema's own docs render them fine, unmodified). matnwb's
+# schema parsing drops the blank lines before fillConstructor.m embeds the
+# text, which is what breaks it here. The proper fix is upstream (preserve
+# blank lines/indentation through codegen); this module is a downstream
+# workaround until that happens.
 import os
 import re
 from _util import list_neurodata_types
@@ -11,6 +21,98 @@ def process_matlab_docstring(app, what, name, obj, options, lines):
     _make_syntax_examples_code_literals(lines)
     _format_input_arguments(lines)
     _split_and_format_example_lines(lines)
+    _escape_role_end_before_invalid_char(lines)
+    _wrap_multiline_argument_descriptions(lines)
+
+
+# Characters allowed to directly follow an inline markup end-string in reST.
+# See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules
+_ALLOWED_CHARS_AFTER_ROLE = re.compile(r"[\s'\")\]}>\-.,:;!?/\\]")
+
+# Matches the closing backtick of an explicit-title role reference, e.g.
+# ":attr:`format <types.core.ImageSeries.format>`", so a "\ " escape can be
+# inserted when matlab_auto_link places such a reference directly before
+# punctuation from the original schema text (e.g. "format='raw'" or
+# "control_description[0]"), which would otherwise break reST parsing.
+_ROLE_END_PATTERN = re.compile(r"(<[^<>`]+>)`")
+
+
+def _escape_role_end_before_invalid_char(lines):
+    def _insert_escape(match):
+        end = match.end()
+        next_char = match.string[end:end + 1]
+        if next_char and not _ALLOWED_CHARS_AFTER_ROLE.match(next_char):
+            return match.group(0) + "\\ "
+        return match.group(0)
+
+    for i, line in enumerate(lines):
+        lines[i] = _ROLE_END_PATTERN.sub(_insert_escape, line)
+
+
+# Matches the first line of a "- name (type) - description" Name-Value
+# Arguments list item (as produced by file.internal.processDocstring /
+# fillConstructor.m), capturing its leading indentation. Runs after
+# _format_input_arguments, so the name/type may already be wrapped in
+# "**...**" / "``...``" markup.
+_ARG_ITEM_START_PATTERN = re.compile(r"^(?P<indent>\s*)-\s+\*{0,2}\w+\*{0,2}\s*(?:\(.*?\))?\s*-\s*\S")
+
+# Inline markup that earlier formatting passes may have applied to a line;
+# stripped from literal-block content below so diagrams/nested lists are
+# shown as their original plain text rather than with stray markup chars.
+_INLINE_MARKUP_PATTERNS = (
+    re.compile(r":[\w:]+:`([^`<]+?)\s*<[^>]+>`\\?\s*"),
+    re.compile(r":[\w:]+:`([^`]+?)`"),
+    re.compile(r"\*\*(.+?)\*\*"),
+    re.compile(r"``(.+?)``"),
+)
+
+
+def _strip_inline_markup(line):
+    for pattern in _INLINE_MARKUP_PATTERNS:
+        line = pattern.sub(r"\1", line)
+    return line
+
+
+def _wrap_multiline_argument_descriptions(lines):
+    """
+    Some schema descriptions (YAML literal block scalars) span multiple
+    lines and may contain nested bullet lists, ASCII diagrams, or other
+    structured text. By the time it reaches this docstring, that content
+    has already lost the blank lines and relative indentation that made it
+    valid reST in the schema source (see module note above), so it fails
+    to parse here (e.g. a nested list immediately following a paragraph
+    with no blank line). Render the continuation as a reST literal block
+    instead, so it is always displayed verbatim rather than being
+    (mis-)parsed as reST.
+
+    Modifies the `lines` list in place.
+    """
+
+    i = 0
+    while i < len(lines):
+        match = _ARG_ITEM_START_PATTERN.match(lines[i])
+        if not match:
+            i += 1
+            continue
+
+        item_index = i
+        i += 1
+        continuation_start = i
+        while i < len(lines) and lines[i].strip() != "":
+            i += 1
+        continuation = lines[continuation_start:i]
+
+        if not continuation:
+            continue
+
+        literal_indent = match.group("indent") + "    "
+        literal_lines = [literal_indent + _strip_inline_markup(cline) for cline in continuation]
+
+        lines[item_index] += "::"
+        lines[continuation_start:i] = [""] + literal_lines
+        i = continuation_start + len(literal_lines) + 1
+
+    return lines
 
 
 def _format_matlab_type_as_code_literal(lines):


### PR DESCRIPTION
## Motivation
**Problem** — the Sphinx docs build has warnings, but nothing catches them: they don't fail CI, and they don't fail the production Read the Docs build. Broken heading structure, mis-rendered docstrings, and unlisted pages can ship straight to the published docs with no signal to anyone.

**Solution** — fix the current set of warnings, then make both CI and the production RTD build fail whenever a Sphinx warning appears, so future regressions are caught before merge instead of shipping silently.

## What changed
- Fixed a heading-level jump in `untyped.rst` (two subsections skipped a level)
- Marked `how_to_cite.rst` as `:orphan:` — it's only reached via direct links, not a toctree, so Sphinx was warning that it's unreachable from navigation
- Fixed reST-breaking auto-linked identifiers when immediately followed by punctuation from the schema text (e.g. a property name auto-linked right before `=` or `[`)
- Fixed the actual root cause of the `OnePhotonSeries`/`TwoPhotonSeries` `data` field warnings: the schema doc string for that field is valid reST as written, but `file.internal.processDocstring` was silently dropping the blank lines between its paragraphs while reflowing it into a MATLAB comment (default `strsplit` behavior), and a one-space indent mismatch in `fillConstructor` then broke the nested list alignment. Fixed both, and regenerated the two affected files
- Added `.github/workflows/build_docs.yml`: builds the docs on PRs/pushes touching `docs/**` or generated `.m` files, fails the job on any Sphinx warning
- Added `fail_on_warning: true` to `.readthedocs.yaml` so the production RTD build also fails on warnings

<details>
<summary>Implementation notes</summary>

Once the blank-line/indent bug above was fixed at the source, the docs-side workaround that had been reconstructing paragraph structure from the mangled text was no longer needed and was removed from `docstring_processors.py`. That file now only contains the one remaining fix needed for auto-linked identifiers next to punctuation, which is unrelated to the blank-line issue.

</details>

## How to test
Run the Sphinx build with warnings treated as errors (`sphinx-build -b html -W --keep-going docs/source docs/build/html`, after running `docs/source/sphinx_extensions/copy_files.py`) and confirm it succeeds with no warnings. The new `Build Sphinx docs` CI check and the Read the Docs PR preview both do this automatically.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
