### PR TITLE
fix: ignore stray files when resolving latest schema version

### DIFF
--- a/+matnwb/+common/findLatestSchemaVersion.m
+++ b/+matnwb/+common/findLatestSchemaVersion.m
@@ -2,11 +2,15 @@ function latestVersion = findLatestSchemaVersion()
 % findLatestSchemaVersion - Find latest available schema version.
 
     schemaListing = dir(fullfile(misc.getMatnwbDir(), 'nwb-schema'));
-    schemaVersionNumbers = setdiff({schemaListing.name}, {'.', '..'});
+
+    % Keep only entries named as version numbers; ignores hidden files like .DS_Store
+    versionNumbers = regexp({schemaListing.name}, '^\d+\.\d+\.\d+$', 'match', 'once');
+    keep = ~cellfun(@isempty, versionNumbers);
+    versionNumbers = versionNumbers(keep);
 
     % Split each version number into major, minor, and patch components
     versionComponents = cellfun(@(v) sscanf(v, '%d.%d.%d'), ...
-        schemaVersionNumbers, 'UniformOutput', false);
+        versionNumbers, 'UniformOutput', false);
     
     % Convert the components into an array for easy comparison
     versionMatrix = cat(2, versionComponents{:})';
@@ -16,5 +20,5 @@ function latestVersion = findLatestSchemaVersion()
     [~, latestIndex] = max(versionMatrix * [1e6; 1e3; 1]); % Weight major, minor, patch
     
     % Return the latest version
-    latestVersion = schemaVersionNumbers{latestIndex};
+    latestVersion = versionNumbers{latestIndex};
 end


### PR DESCRIPTION
## Motivation

**Problem** — On macOS, Finder silently drops a `.DS_Store` file into MatNWB's `nwb-schema/` folder as soon as the folder is browsed. Any such stray entry makes `generateCore()` (called without a version argument, i.e. "use latest") silently resolve to an old schema version — `2.1.0` instead of `2.10.0` — so the user unknowingly generates classes for a years-old schema. No error or warning is raised.

**Solution** — When determining the latest schema version, only folder entries whose name is an exact `major.minor.patch` version number are considered, so stray files can no longer influence the result.

## What changed

- `matnwb.common.findLatestSchemaVersion` (used by `generateCore` to resolve the default schema version) now ignores any entry in `nwb-schema/` that is not named as an exact version number.
- Behavior with a clean `nwb-schema/` folder is unchanged.

<details><summary>Implementation notes</summary>

Previously only `.` and `..` were excluded from the directory listing. For any other non-version entry, `sscanf(name, '%d.%d.%d')` returned empty, silently dropping that entry from the version-comparison matrix while it remained in the name list — an off-by-one that made the max-version index point at the wrong name. Entries are now filtered with the anchored pattern `^\d+\.\d+\.\d+$` before parsing.

</details>

## Examples

With a stray (hidden) file present in `nwb-schema/`:

```matlab
strayFile = fullfile(misc.getMatnwbDir(), 'nwb-schema', '.stray_test_file');
fclose(fopen(strayFile, 'w'));
latestVersion = matnwb.common.findLatestSchemaVersion()
delete(strayFile)
```

**Before** (silently wrong version):

```
latestVersion =

    '2.1.0'
```

**After**:

```
latestVersion =

    '2.10.0'
```

## How to test

Run the snippet above on this branch — the result is `'2.10.0'` regardless of stray files in `nwb-schema/`. On macOS, simply browsing `nwb-schema/` in Finder (which creates `.DS_Store`) and then calling `generateCore()` also exercises the fix.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
