### PR TITLE
Raise error from inspectNwbFile when PyNWB cannot read the file

### DIFF
--- a/+tests/+unit/NwbInspectorWrapperTest.m
+++ b/+tests/+unit/NwbInspectorWrapperTest.m
@@ -50,6 +50,26 @@ classdef (SharedTestFixtures = {tests.fixtures.SetEnvironmentVariableFixture}) .
             report = inspectNwbFile('ecephys_tutorial.nwb', 'UseCLI', true);
             testCase.verifyClass(report, 'table')
         end
+
+        function testErrorWhenPyNwbCannotReadFile(testCase)
+            if testCase.skipIfNwbInspectorTest()
+                return
+            end
+            % nwbinspector reports a PyNWB read failure as an ERROR-level
+            % message instead of raising. Because no checks run on such a
+            % file, inspectNwbFile must raise rather than return a report.
+            nwbFile = tests.factory.NWBFile();
+            nwbExport(nwbFile, 'unreadable.nwb');
+            % Removing a required dataset makes PyNWB fail on read
+            deleteLink('unreadable.nwb', '/session_description');
+
+            testCase.verifyError(...
+                @() inspectNwbFile('unreadable.nwb'), ...
+                'NWB:InspectNwbFile:FileReadError')
+            testCase.verifyError(...
+                @() inspectNwbFile('unreadable.nwb', 'UseCLI', true), ...
+                'NWB:InspectNwbFile:FileReadError')
+        end
     end
 
     methods (Static, Access = private)
@@ -65,4 +85,10 @@ classdef (SharedTestFixtures = {tests.fixtures.SetEnvironmentVariableFixture}) .
             end
         end
     end
+end
+
+function deleteLink(filename, linkPath)
+    fileId = H5F.open(filename, 'H5F_ACC_RDWR', 'H5P_DEFAULT');
+    fileCleanup = onCleanup(@() H5F.close(fileId)); %#ok<NASGU>
+    H5L.delete(fileId, linkPath, 'H5P_DEFAULT');
 end

--- a/inspectNwbFile.m
+++ b/inspectNwbFile.m
@@ -19,7 +19,9 @@ function result = inspectNwbFile(nwbFilepath, options)
 %      Which order to arrange the variables in the tabular report.
 % 
 % Output Arguments:
-%  - report (table) - A tabular report listing nwbinspector issues
+%  - report (table) - A tabular report listing nwbinspector issues. If PyNWB
+%    fails to read the file, no checks are run and an error is raised instead
+%    of returning a report.
 %
 % Usage:
 %  Example 1 - Inspect an NWB file::
@@ -95,7 +97,32 @@ function result = inspectNwbFile(nwbFilepath, options)
         error('NWB:InspectNwbFile:NwbInspectorNotFound', ...
             'Did not find nwbinspector. See `help inspectNwbFile` for more details')
     end
+    throwErrorIfFileCouldNotBeRead(result, nwbFilepath)
     result = result(:, options.VariableOrder);
+end
+
+function throwErrorIfFileCouldNotBeRead(resultTable, nwbFilepath)
+% throwErrorIfFileCouldNotBeRead - Raise an error if PyNWB could not read the file.
+%
+%   nwbinspector does not raise when PyNWB fails to read a file. It returns a
+%   single message with importance ERROR whose check_function_name is a
+%   sentence starting with "During io.read()" and whose message is the Python
+%   traceback (see nwbinspector._nwb_inspection.inspect_nwbfile). Such a
+%   result means no checks ran at all, so returning it as a report would
+%   silently let an unreadable file "pass". nwbinspector provides no
+%   structured marker for this case, so the prefix is matched as text. See
+%   https://github.com/NeurodataWithoutBorders/nwbinspector/issues/723
+
+    READ_ERROR_PREFIX = "During io.read(), an error occurred";
+
+    isReadError = startsWith(string(resultTable.check_function_name), READ_ERROR_PREFIX);
+    if any(isReadError)
+        pythonTraceback = strjoin(string(resultTable.message(isReadError)), newline);
+        error('NWB:InspectNwbFile:FileReadError', ...
+            ['nwbinspector could not inspect "%s" because PyNWB failed to read ', ...
+            'the file, so no checks were run. The Python traceback was:\n%s'], ...
+            nwbFilepath, pythonTraceback)
+    end
 end
 
 function resultTable = convertNwbInspectorResultsToTable(resultsIn)


### PR DESCRIPTION
## Motivation

**Problem** — When PyNWB cannot read a file, nwbinspector does not raise. It returns a single `ERROR`-level message whose `check_function_name` is a prose sentence ("During io.read(), an error occurred: ...") and whose `message` is the Python traceback. `inspectNwbFile` passed this straight through as a one-row report table. For a user that is a trap: no checks ran at all, but the result looks like an ordinary finding, and any workflow that filters by importance, counts rows, or asserts "no CRITICAL findings" silently treats an unreadable file as one that passed inspection.

**Solution** — `inspectNwbFile` now raises `NWB:InspectNwbFile:FileReadError`, with the Python traceback included in the message, whenever nwbinspector reports that PyNWB failed to read the file. Valid files are unaffected. Upstream, [nwbinspector #723](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/723) asks for an opt-in raise; until nwbinspector exposes a structured marker, the message prefix is matched as text.

## What changed

- `inspectNwbFile` raises `NWB:InspectNwbFile:FileReadError` instead of returning a report when PyNWB fails to read the file. Applies to both the Python-module and CLI code paths.
- The function help states that an unreadable file raises rather than returning a report.
- New unit test `testErrorWhenPyNwbCannotReadFile` in `NwbInspectorWrapperTest` covers both code paths.

## Examples

Setup — export a valid file, then remove a required dataset so PyNWB fails on read:

```matlab
nwb = NwbFile('identifier', 'demo', 'session_description', 'demo', ...
    'session_start_time', datetime(2026,8,21,12,0,0, 'TimeZone', 'local'));
nwbExport(nwb, 'unreadable.nwb');
fileId = H5F.open('unreadable.nwb', 'H5F_ACC_RDWR', 'H5P_DEFAULT');
H5L.delete(fileId, '/session_description', 'H5P_DEFAULT');
H5F.close(fileId);

report = inspectNwbFile('unreadable.nwb');
```

**Before** — a report is returned as if the file had been inspected:

```
class: table, rows: 1
    importance    check_function_name
    __________    ________________________________________________________________________________________________________________________________________________________________
     "ERROR"      "During io.read(), an error occurred: hdmf.build.errors.ConstructError. This indicates that PyNWB was unable to read the file. See the traceback message for more details."
```

**After** — an error, for both `inspectNwbFile(file)` and `inspectNwbFile(file, 'UseCLI', true)`:

```
NWB:InspectNwbFile:FileReadError
nwbinspector could not inspect "unreadable.nwb" because PyNWB failed to read the file, so no checks were run. The Python traceback was:
Traceback (most recent call last):
  ...
hdmf.build.errors.ConstructError: ...
```

## How to test

Run the setup above, then:

```matlab
try
    inspectNwbFile('unreadable.nwb');
catch ME
    disp(ME.identifier)   % NWB:InspectNwbFile:FileReadError
end
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


