### PR TITLE
CI/test: restore ContainerDisplayMode preference state via fixture

### DIFF
--- a/+tests/+fixtures/PreferenceFixture.m
+++ b/+tests/+fixtures/PreferenceFixture.m
@@ -1,0 +1,45 @@
+classdef PreferenceFixture < matlab.unittest.fixtures.Fixture
+% PreferenceFixture Fixture that sets a MATLAB preference for the duration of a test.
+%
+%   On setup, the fixture records the current state of the preference and sets
+%   it to the requested value. On teardown, the original value is restored. If
+%   the preference did not exist before setup, it is removed again on teardown
+%   so that running the tests never leaves a new preference behind on the
+%   user's machine.
+%
+%   Example:
+%       testCase.applyFixture( ...
+%           tests.fixtures.PreferenceFixture('matnwb', 'ContainerDisplayMode', 'groups'))
+
+    properties (SetAccess = immutable)
+        Group (1,1) string
+        Name (1,1) string
+        Value
+    end
+
+    methods
+        function fixture = PreferenceFixture(group, name, value)
+            fixture.Group = group;
+            fixture.Name = name;
+            fixture.Value = value;
+        end
+
+        function setup(fixture)
+            if ispref(fixture.Group, fixture.Name)
+                originalValue = getpref(fixture.Group, fixture.Name);
+                fixture.addTeardown(@() setpref(fixture.Group, fixture.Name, originalValue))
+            else
+                fixture.addTeardown(@() rmpref(fixture.Group, fixture.Name))
+            end
+            setpref(fixture.Group, fixture.Name, fixture.Value)
+        end
+    end
+
+    methods (Access = protected)
+        function tf = isCompatible(fixtureA, fixtureB)
+            tf = strcmp(fixtureA.Group, fixtureB.Group) ...
+                && strcmp(fixtureA.Name, fixtureB.Name) ...
+                && isequal(fixtureA.Value, fixtureB.Value);
+        end
+    end
+end

--- a/+tests/+system/AlignedDynamicTableTest.m
+++ b/+tests/+system/AlignedDynamicTableTest.m
@@ -27,9 +27,8 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
 
         function testDisplayTipRecommendsAddCategory(testCase)
             % Verify "groups" display mode
-            origPrefValue = getpref('matnwb', 'ContainerDisplayMode', 'flat');
-            testCase.addTeardown(@() setpref('matnwb', 'ContainerDisplayMode', origPrefValue))
-            setpref('matnwb', 'ContainerDisplayMode', 'groups')
+            testCase.applyFixture( ...
+                tests.fixtures.PreferenceFixture('matnwb', 'ContainerDisplayMode', 'groups'))
 
             displayText = evalc( ...
                 'disp(tests.system.AlignedDynamicTableTest.createAlignedTable())');

--- a/+tests/+system/AlignedDynamicTableTest.m
+++ b/+tests/+system/AlignedDynamicTableTest.m
@@ -27,7 +27,7 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
 
         function testDisplayTipRecommendsAddCategory(testCase)
             % Verify "groups" display mode
-            origPrefValue = getpref('matnwb', 'ContainerDisplayMode');
+            origPrefValue = getpref('matnwb', 'ContainerDisplayMode', 'flat');
             testCase.addTeardown(@() setpref('matnwb', 'ContainerDisplayMode', origPrefValue))
             setpref('matnwb', 'ContainerDisplayMode', 'groups')
 

--- a/+tests/+unit/HasUnnamedGroupsTest.m
+++ b/+tests/+unit/HasUnnamedGroupsTest.m
@@ -215,10 +215,8 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
             module.add('DynamicTable', types.hdmf_common.DynamicTable());
 
             % Verify both display modes
-            origPrefValue = getpref('matnwb', 'ContainerDisplayMode', 'flat');
-            testCase.addTeardown(@() setpref('matnwb', 'ContainerDisplayMode', origPrefValue))
-
-            setpref('matnwb', 'ContainerDisplayMode', 'flat')
+            testCase.applyFixture( ...
+                tests.fixtures.PreferenceFixture('matnwb', 'ContainerDisplayMode', 'flat'))
             C = evalc('disp(module)');
             testCase.verifyFalse(contains(C, 'nwbdatainterface group'))
             testCase.verifyFalse(contains(C, 'dynamictable group'))


### PR DESCRIPTION
## Motivation
**Background** — Containers with unnamed groups (e.g. `ProcessingModule`, `AlignedDynamicTable`) have a configurable command-window display. The mode is read from a MATLAB preference, `getpref('matnwb', 'ContainerDisplayMode')`, with three values: `'groups'` (the default, shows each unnamed group as its own section), `'flat'` (lists the contained objects as plain properties) and `'legacy'`. The preference is a low-profile opt-in — it is only mentioned in the "working with containers" how-to and is not set by MatNWB itself — so on most machines, including CI runners, it has never been set. Two tests exercise the display modes by temporarily switching it.

**Problem** — On a machine where the preference has never been set, `AlignedDynamicTableTest/testDisplayTipRecommendsAddCategory` errors before reaching its assertions: the unconditional `getpref` call that captures the original value throws `preference ContainerDisplayMode does not exist in group matnwb`, failing the test suite. The obvious fix — reading the preference with a fallback, as `HasUnnamedGroupsTest` already did — has its own side effect: the teardown then *persists* the fallback (`'flat'`) into the user's preferences, silently switching their display mode away from the `'groups'` default for every future session.

**Solution** — Introduce a `PreferenceFixture` that sets a preference for the duration of a test and, on teardown, restores the original value or removes the preference if it did not exist beforehand. Both tests now use it, so the suite passes on a clean installation and never leaves a preference behind.

## What changed
- `AlignedDynamicTableTest/testDisplayTipRecommendsAddCategory` no longer errors when `ContainerDisplayMode` is unset.
- Neither that test nor `HasUnnamedGroupsTest/testObjectDisplay` persists a `ContainerDisplayMode` preference on machines where it was previously absent.
- New reusable `tests.fixtures.PreferenceFixture(group, name, value)` for any test that needs to temporarily set a MATLAB preference.

## Examples

Running `testDisplayTipRecommendsAddCategory` on a machine where the preference has never been set:

**Before**
```
preference ContainerDisplayMode does not exist in group matnwb
```

**After**
```
    Name                                                                        Passed    Failed
    tests.system.AlignedDynamicTableTest/testDisplayTipRecommendsAddCategory    true      false

Pref exists after tests (expect 0): 0
```

## How to test
```matlab
if ispref('matnwb', 'ContainerDisplayMode')
    rmpref('matnwb', 'ContainerDisplayMode')
end
runtests({ ...
    'tests.system.AlignedDynamicTableTest/testDisplayTipRecommendsAddCategory', ...
    'tests.unit.HasUnnamedGroupsTest/testObjectDisplay'})
ispref('matnwb', 'ContainerDisplayMode')  % expect false
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
