### PR TITLE
CI: Pin pynwb and nwbinspector in a versioned requirements file

### DIFF
--- a/+tests/requirements-python310.txt
+++ b/+tests/requirements-python310.txt
@@ -1,0 +1,15 @@
+# Test dependencies that require Python 3.10 or later.
+# Installed conditionally by the test workflows; see +tests/requirements.txt
+# for the dependencies installed on every supported Python version.
+#
+# These versions are pinned so that test and release runs are predictable: the
+# result depends only on what is in the branch, not on which pynwb or
+# nwbinspector release happens to be current that day. Without a pin, an
+# upstream release can fail a pull request check or a release run that has
+# nothing to do with the change being tested.
+#
+# Dependabot opens a pull request when a newer release is published, so an
+# upstream change is tested on its own before anything depends on it. Both
+# workflows read this file, so test and release runs also stay in step.
+pynwb==4.1.0
+nwbinspector==0.7.2

--- a/+tests/requirements.txt
+++ b/+tests/requirements.txt
@@ -4,6 +4,7 @@ hdf5plugin
 dataframe_image     # Used by PyNWB "Icepys pandas" tutorial
 Pillow              # Used by PyNWB "Images" tutorial
 
-# Note: pynwb and nwbinspector are installed conditionally in the workflow files
-# (only for Python 3.10+, as both packages dropped Python 3.9 support)
-# For local testing, install manually
+# Note: pynwb and nwbinspector are pinned in +tests/requirements-python310.txt and
+# installed conditionally by the workflow files (only for Python 3.10+, as both
+# packages dropped Python 3.9 support). For local testing on Python 3.10 or later:
+#   pip install -r +tests/requirements-python310.txt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Keep the pinned Python test dependencies current.
+# Dependabot opens a pull request when pynwb or nwbinspector publishes a new
+# release, so the bump runs through CI before it applies to any branch.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/+tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -72,12 +72,11 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -r +tests/requirements.txt
-          # Install pynwb and nwbinspector only for Python 3.10+ (both dropped Python 3.9 support)
+          # Install pynwb and nwbinspector only for Python 3.10+ (both dropped Python 3.9 support).
+          # Release tests use the same pinned releases as run_tests.yml; dev-branch
+          # compatibility is covered separately by run_pynwb_dev_tests.yml.
           if [[ "${{ matrix.skip-pynwb-tests }}" == "0" ]]; then
-            pip install "git+https://github.com/NeurodataWithoutBorders/pynwb.git@dev"
-          fi
-          if [[ "${{ matrix.skip-nwbinspector-test }}" == "0" ]]; then
-            pip install "git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@dev"
+            pip install -r +tests/requirements-python310.txt
           fi
           python -m pip list
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -107,12 +107,9 @@ jobs:
           pip install -r +tests/requirements.txt
           # Install pynwb and nwbinspector only for Python 3.10+ (both dropped Python 3.9 support)
           if [[ "${{ matrix.skip-pynwb-tests }}" == "0" ]]; then
-            pip install "pynwb==4.0.0"
+            pip install -r +tests/requirements-python310.txt
             pynwb_version=$(pip show pynwb | grep "^Version:" | awk '{print $2}')
             echo "pynwb_version=$pynwb_version" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ matrix.skip-nwbinspector-test }}" == "0" ]]; then
-            pip install nwbinspector
           fi
           python -m pip list
           echo "HDF5_PLUGIN_PATH=$(python -c "import hdf5plugin; print(hdf5plugin.PLUGINS_PATH)")" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Motivation

**Problem** — CI installed pynwb and nwbinspector versions that could change without any change to MatNWB. `run_tests.yml` installed unpinned nwbinspector (latest release), and `prepare_release.yml` installed both packages from their dev branches. A pull request check or a release run could therefore fail because an upstream release changed, not because anything in the branch was wrong — This blocks a PR or release due to shifting pynwb/nwbinspector behaviour, not de to MatNWB regressions or bugs.

**Solution** — Both workflows install fixed versions from one file in the repository, so a run's result depends only on what is in the branch. New upstream releases arrive as a Dependabot pull request instead, where the new version is tested on its own before anything depends on it.

## What changed

- `+tests/requirements-python310.txt` (new) pins `pynwb==4.1.0` and `nwbinspector==0.7.2`. Both `run_tests.yml` and `prepare_release.yml` install it on the Python 3.10+ matrix rows, so neither workflow can pick up a new upstream release mid-branch, and the two stay in step with each other.
- `prepare_release.yml` no longer installs pynwb and nwbinspector from their dev branches. Dev-branch compatibility is covered by the unchanged weekly `run_pynwb_dev_tests.yml`, which selects `UsesPython`-tagged tests.
- `.github/dependabot.yml` (new) checks the pins weekly and opens a bump pull request when a newer release exists.
- The pins are versioned, so `git log` records which package versions any commit or release tag was tested against, and a bump can be reviewed, bisected, and reverted like any other change.

<details><summary>Implementation notes</summary>

- Both packages install under the single `skip-pynwb-tests` matrix gate, which marks the Python 3.10+ rows. Skipping the nwbinspector test on its own still works, because that is passed to MATLAB separately through `SKIP_NWBINSPECTOR_TEST`.
- Installing from one requirements file lets pip resolve both pins together. Two sequential `pip install` commands can silently downgrade one package to satisfy the other; a single file makes an incompatible pair fail the install instead.
- `run_tests.yml` still reads the installed version with `pip show pynwb`, which selects the matching pynwb repository tag for the tutorial tests.
- `+tests/requirements.txt` is unchanged apart from its note, which now points at the new file and gives the local install command.

</details>

## Examples

The pinned versions each workflow resolves, using `pip install --dry-run --no-deps`.

**Before** — `run_tests.yml` installed a pinned pynwb and an unpinned nwbinspector:

```
$ pip install --dry-run --no-deps "pynwb==4.0.0" nwbinspector
Would install nwbinspector-0.7.2 pynwb-4.0.0
```

pynwb is held at 4.0.0 while 4.1.0 is the current release, and the nwbinspector version is whatever PyPI serves on the day the job runs. `prepare_release.yml` resolved neither of these, installing both packages from `@dev` instead.

**After** — both workflows resolve the same file:

```
$ pip install --dry-run --no-deps -r +tests/requirements-python310.txt
Would install nwbinspector-0.7.2 pynwb-4.1.0
```

## How to test

Resolve the pins without installing anything into your environment:

```bash
python3 -m venv /tmp/pinvenv
/tmp/pinvenv/bin/pip install --dry-run -r +tests/requirements-python310.txt
```

The report ends with `Would install ... nwbinspector-0.7.2 ... pynwb-4.1.0`, confirming the two pins resolve together without a conflict.

After merge, Dependabot can be checked from the repository's Insights → Dependency graph → Dependabot tab, which lists the `pip` entry and reports any configuration error.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
