### PR TITLE
CI: run TutorialTest against the pynwb and nwbinspector dev branches

### DIFF
--- a/+tests/+system/+tutorial/TutorialTest.m
+++ b/+tests/+system/+tutorial/TutorialTest.m
@@ -66,7 +66,13 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture, tests.fixtur
         end
     end
     
-    methods (Test)
+    % Tagged UsesPythonWhenAvailable, not UsesPython. The UsesPython tag drives
+    % the SKIP_PYNWB_TESTS exclusion in nwbtest, which would drop this class
+    % entirely on MATLAB releases pinned to Python 3.9 and stop the tutorials
+    % from running there at all. The pynwb and nwbinspector checks below gate
+    % themselves on the environment variables instead, so the tutorials keep
+    % running when Python is unavailable.
+    methods (Test, TestTags = {'UsesPythonWhenAvailable'})
         function testTutorial(testCase, tutorialFile) %#ok<INUSD>
             % Intentionally capturing output, in order for tests to cover
             % code which overloads display methods for nwb types/objects.

--- a/+tests/README.md
+++ b/+tests/README.md
@@ -53,7 +53,17 @@ Supporting packages:
 ## Setting up Python-dependent tests
 
 Some tests use Python for PyNWB interoperability and NWB file validation.
-These tests are tagged `UsesPython` and require additional setup.
+These tests are tagged and require additional setup. Two tags describe how
+strongly a test depends on Python:
+
+| Tag | Meaning |
+|---|---|
+| `UsesPython` | The test cannot run without Python. `nwbtest` excludes it when `SKIP_PYNWB_TESTS=1`. |
+| `UsesPythonWhenAvailable` | The test has a Python component but runs without it. `nwbtest` never excludes it; the test skips its own Python checks when `SKIP_PYNWB_TESTS=1`. |
+
+`TutorialTest` carries `UsesPythonWhenAvailable`: it runs every tutorial
+livescript regardless of Python, and additionally reads each generated NWB file
+back with PyNWB and inspects it with NWBInspector when those are available.
 
 ### 1. Install Python packages
 
@@ -123,7 +133,7 @@ variables at test startup. If `nwbtest.env` does not exist, it falls back to
 
 ### Skipping Python tests
 
-If Python is not available or not needed, skip all Python-dependent tests:
+If Python is not available or not needed, skip the tests that require it:
 
 ```matlab
 setenv('SKIP_PYNWB_TESTS', '1')
@@ -131,6 +141,9 @@ nwbtest()
 ```
 
 Or set `SKIP_PYNWB_TESTS=1` in your `nwbtest.env` file.
+
+This drops the whole test suite for classes tagged `UsesPython`. Classes tagged
+`UsesPythonWhenAvailable` still run, minus their Python checks.
 
 ## Setting up dynamically loaded HDF5 filter tests
 
@@ -167,8 +180,13 @@ _System Properties > Advanced > Environment Variables_ and restart MATLAB.
 
 - Test classes inherit from `matlab.unittest.TestCase` (or `tests.abstract.NwbTestCase` for tests that need generated NWB types)
 - Test method names start with `test` (e.g., `testSmoke`, `testRoundTrip`)
-- Python-dependent tests are tagged `UsesPython`
+- Tests that require Python are tagged `UsesPython`; tests with an optional Python component are tagged `UsesPythonWhenAvailable` (see [Setting up Python-dependent tests](#setting-up-python-dependent-tests))
 - Tests requiring dynamically loaded HDF5 filters are tagged `UsesDynamicallyLoadedFilters` (MATLAB R2022a+)
+
+The weekly `PyNWB dev branch compatibility` workflow selects both Python tags,
+so a test with an optional Python component is checked against the pynwb and
+nwbinspector dev branches without being excluded on releases where Python is
+unavailable.
 
 ### Placing `TestTags` on the `methods` block, not the classdef
 

--- a/+tests/nwbtest.default.env
+++ b/+tests/nwbtest.default.env
@@ -30,4 +30,8 @@ PYNWB_REPO_DIR=
 # Set to 1 to skip all tests tagged UsesPython (PyNWBIOTest, NwbInspectorWrapperTest,
 # PynwbTutorialTest). Set automatically by the CI matrix for MATLAB releases that
 # use Python 3.9, where pynwb is not supported. Default is 0 (run Python tests).
+#
+# Tests tagged UsesPythonWhenAvailable (TutorialTest) are not excluded by this
+# variable. They read it themselves and skip only their Python checks, so the
+# tutorials keep running when pynwb is unavailable.
 SKIP_PYNWB_TESTS=0

--- a/.github/workflows/run_pynwb_dev_tests.yml
+++ b/.github/workflows/run_pynwb_dev_tests.yml
@@ -60,7 +60,8 @@ jobs:
             setenv("SKIP_PYNWB_TESTS", "0")
             setenv("SKIP_NWBINSPECTOR_TEST", "0")
             pyenv("ExecutionMode", "OutOfProcess");
-            results = nwbtest('ReportOutputFolder', '.', 'Tag', 'UsesPython');
+            results = nwbtest('ReportOutputFolder', '.', ...
+                'Tag', {'UsesPython', 'UsesPythonWhenAvailable'});
             assert(~isempty(results), 'No tests ran');
             assertSuccess(results);
 

--- a/.github/workflows/run_pynwb_dev_tests.yml
+++ b/.github/workflows/run_pynwb_dev_tests.yml
@@ -52,6 +52,11 @@ jobs:
         uses: matlab-actions/setup-matlab@v3
         with:
           release: ${{ steps.set-versions.outputs.matlab_version }}
+          # This workflow runs on a schedule, so it runs on the default branch
+          # and reads the cache entry run_tests.yml writes there for the latest
+          # release. Same release and no product list means the same cache key,
+          # so this reuses that entry rather than storing a second copy.
+          cache: true
 
       - name: Run PyNWB-dependent tests
         uses: matlab-actions/run-command@v3


### PR DESCRIPTION
## Background
A recurring weekly workflow `PyNWB dev branch compatibility` tests MatNWB compatibility against the PyNWB development (`dev`) branch and the nwbinspector development branch. It currently includes the following tests:

- `PyNWBIOTest` - Simple in out between MatNWB and PyNWB
- `PynwbTutorialTest` - Run PyNWB tutorials and read with MatNWB
- `NwbInspectorWrapperTest` - Test nwb inspector wrapper

## Problem
One more test should be included but is not:
- `TutorialTest` - Run each MatNWB tutorial livescript and read it back with PyNWB.

It cannot simply be tagged `UsesPython` like the others. That tag also drives the `SKIP_PYNWB_TESTS` exclusion in `nwbtest`, which the CI matrix sets for the MATLAB releases pinned to Python 3.9. Tagging `TutorialTest` would stop the tutorials running on those releases entirely.

## Solution
Add a second tag, `UsesPythonWhenAvailable`, for tests that have a Python component but still run without it. `nwbtest` does not exclude on it, because such tests gate their own Python checks on `SKIP_PYNWB_TESTS` — which `TutorialTest` already does. The weekly workflow selects both tags.

Adds about 55 s to a test step that currently takes 4.5 minutes.

Also enables the MATLAB install cache for this workflow. It runs on a schedule, so it runs on the default branch and reads the entry `run_tests.yml` already stores there for the latest release. Same release and no product list means the same cache key, so it reuses that entry rather than storing a second copy, and saves about 1m40s per run.

## Note on nwbinspector

`TutorialTest` also runs NWBInspector on the tutorial output, so this workflow now catches new checks landing on the nwbinspector dev branch too. `filterNWBInspectorResults` keeps a `CHECK_IGNORE` list tuned against the pinned version, so such a check can fail here — which is the point of a workflow that doesn't gate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
