### PR TITLE
refactor(tests): rename test dependency tags to a Requires prefix

### DIFF
--- a/+tests/+system/+tutorial/PynwbTutorialTest.m
+++ b/+tests/+system/+tutorial/PynwbTutorialTest.m
@@ -57,7 +57,7 @@ classdef (SharedTestFixtures = {tests.fixtures.SetEnvironmentVariableFixture}) .
         end
     end
 
-    methods (Test, TestTags = {'UsesPython'})
+    methods (Test, TestTags = {'RequiresPython'})
         function testTutorial(testCase, TutorialFile)
             galleryFolder = fullfile(pwd, 'docs', 'gallery');
             tutorialFilePath = fullfile(galleryFolder, TutorialFile);

--- a/+tests/+system/+tutorial/TutorialTest.m
+++ b/+tests/+system/+tutorial/TutorialTest.m
@@ -66,12 +66,12 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture, tests.fixtur
         end
     end
     
-    % Tagged UsesPythonWhenAvailable, not UsesPython. The UsesPython tag drives
-    % the SKIP_PYNWB_TESTS exclusion in nwbtest, which would drop this class
-    % entirely on MATLAB releases pinned to Python 3.9 and stop the tutorials
-    % from running there at all. The pynwb and nwbinspector checks below gate
-    % themselves on the environment variables instead, so the tutorials keep
-    % running when Python is unavailable.
+    % Tagged UsesPythonWhenAvailable, not RequiresPython. The RequiresPython
+    % tag drives the SKIP_PYNWB_TESTS exclusion in nwbtest, which would drop
+    % this class entirely on MATLAB releases pinned to Python 3.9 and stop the
+    % tutorials from running there at all. The pynwb and nwbinspector checks
+    % below gate themselves on the environment variables instead, so the
+    % tutorials keep running when Python is unavailable.
     methods (Test, TestTags = {'UsesPythonWhenAvailable'})
         function testTutorial(testCase, tutorialFile) %#ok<INUSD>
             % Intentionally capturing output, in order for tests to cover

--- a/+tests/+system/PyNWBIOTest.m
+++ b/+tests/+system/PyNWBIOTest.m
@@ -7,7 +7,7 @@ classdef (SharedTestFixtures = {tests.fixtures.SetEnvironmentVariableFixture}) .
     %
     % To install unittest2, execute:
     % $ pip install unittest2
-    methods(Test, TestTags={'UsesPython'})
+    methods(Test, TestTags={'RequiresPython'})
         function testOutToPyNWB(testCase)
             filename = ['MatNWB.' testCase.className() '.testOutToPyNWB.nwb'];
             nwbExport(testCase.file, filename);

--- a/+tests/+unit/+io/+config/ApplyDatasetConfigurationTest.m
+++ b/+tests/+unit/+io/+config/ApplyDatasetConfigurationTest.m
@@ -29,7 +29,7 @@ classdef ApplyDatasetConfigurationTest < tests.abstract.NwbTestCase
         end
     end
     
-    methods (Test, TestTags={'UsesDynamicallyLoadedFilters'})
+    methods (Test, TestTags={'RequiresDynamicallyLoadedFilters'})
         function testCustomConfiguration(testCase)
             nwbFile = tests.factory.NWBFile();
             

--- a/+tests/+unit/+io/+config/CompressionConfigurationTest.m
+++ b/+tests/+unit/+io/+config/CompressionConfigurationTest.m
@@ -66,7 +66,7 @@ classdef CompressionConfigurationTest < matlab.unittest.TestCase
         end
     end
 
-    methods (Test, TestTags={'UsesDynamicallyLoadedFilters'})
+    methods (Test, TestTags={'RequiresDynamicallyLoadedFilters'})
         
         function testCustomCompressionMethod(testCase)
             CUSTOM_COMPRESSION_METHOD = "ZStandard";

--- a/+tests/+unit/NwbInspectorWrapperTest.m
+++ b/+tests/+unit/NwbInspectorWrapperTest.m
@@ -9,7 +9,7 @@ classdef (SharedTestFixtures = {tests.fixtures.SetEnvironmentVariableFixture}) .
         end
     end
 
-    methods (Test, TestTags={'UsesPython'})
+    methods (Test, TestTags={'RequiresPython'})
         function testNwbInspector(testCase)
             if testCase.skipIfNwbInspectorTest()
                 return

--- a/+tests/+unit/dataPipeTest.m
+++ b/+tests/+unit/dataPipeTest.m
@@ -407,7 +407,7 @@ classdef (SharedTestFixtures = {tests.fixtures.GenerateCoreFixture}) ...
         end
     end
 
-    methods (Test, TestTags={'UsesDynamicallyLoadedFilters'})
+    methods (Test, TestTags={'RequiresDynamicallyLoadedFilters'})
                 
         function testExternalFilters(testCase)
             import types.untyped.datapipe.dynamic.Filter;

--- a/+tests/README.md
+++ b/+tests/README.md
@@ -58,7 +58,7 @@ strongly a test depends on Python:
 
 | Tag | Meaning |
 |---|---|
-| `UsesPython` | The test cannot run without Python. `nwbtest` excludes it when `SKIP_PYNWB_TESTS=1`. |
+| `RequiresPython` | The test cannot run without Python. `nwbtest` excludes it when `SKIP_PYNWB_TESTS=1`. |
 | `UsesPythonWhenAvailable` | The test has a Python component but runs without it. `nwbtest` never excludes it; the test skips its own Python checks when `SKIP_PYNWB_TESTS=1`. |
 
 `TutorialTest` carries `UsesPythonWhenAvailable`: it runs every tutorial
@@ -142,12 +142,12 @@ nwbtest()
 
 Or set `SKIP_PYNWB_TESTS=1` in your `nwbtest.env` file.
 
-This drops the whole test suite for classes tagged `UsesPython`. Classes tagged
+This drops the whole test suite for classes tagged `RequiresPython`. Classes tagged
 `UsesPythonWhenAvailable` still run, minus their Python checks.
 
 ## Setting up dynamically loaded HDF5 filter tests
 
-Tests tagged `UsesDynamicallyLoadedFilters` require MATLAB R2022a or newer and
+Tests tagged `RequiresDynamicallyLoadedFilters` need MATLAB R2022a or newer and
 HDF5 filter plugins to be available. The easiest way to set this up is via the
 `hdf5plugin` Python package.
 
@@ -180,8 +180,12 @@ _System Properties > Advanced > Environment Variables_ and restart MATLAB.
 
 - Test classes inherit from `matlab.unittest.TestCase` (or `tests.abstract.NwbTestCase` for tests that need generated NWB types)
 - Test method names start with `test` (e.g., `testSmoke`, `testRoundTrip`)
-- Tests that require Python are tagged `UsesPython`; tests with an optional Python component are tagged `UsesPythonWhenAvailable` (see [Setting up Python-dependent tests](#setting-up-python-dependent-tests))
-- Tests requiring dynamically loaded HDF5 filters are tagged `UsesDynamicallyLoadedFilters` (MATLAB R2022a+)
+- Tests that require Python are tagged `RequiresPython`; tests with an optional Python component are tagged `UsesPythonWhenAvailable` (see [Setting up Python-dependent tests](#setting-up-python-dependent-tests))
+- Tests requiring dynamically loaded HDF5 filters are tagged `RequiresDynamicallyLoadedFilters` (MATLAB R2022a+)
+
+A tag name states how strongly the test depends on the thing it names. A
+`Requires*` tag means `nwbtest` drops the test entirely when that dependency is
+unavailable, so a test that degrades gracefully on its own must not carry one.
 
 The weekly `PyNWB dev branch compatibility` workflow selects both Python tags,
 so a test with an optional Python component is checked against the pynwb and
@@ -197,14 +201,14 @@ issue with the MATLAB domain for Sphinx documentation generation
 
 ```matlab
 % Correct
-methods (Test, TestTags = {'UsesPython'})
+methods (Test, TestTags = {'RequiresPython'})
     function testSomething(testCase)
         ...
     end
 end
 
 % Avoid
-classdef (TestTags = {'UsesPython'}) MyTest < matlab.unittest.TestCase
+classdef (TestTags = {'RequiresPython'}) MyTest < matlab.unittest.TestCase
     ...
 end
 ```

--- a/+tests/nwbtest.default.env
+++ b/+tests/nwbtest.default.env
@@ -27,7 +27,7 @@ PYTHON_EXECUTABLE=python
 # Example: PYNWB_REPO_DIR=/home/user/pynwb
 PYNWB_REPO_DIR=
 
-# Set to 1 to skip all tests tagged UsesPython (PyNWBIOTest, NwbInspectorWrapperTest,
+# Set to 1 to skip all tests tagged RequiresPython (PyNWBIOTest, NwbInspectorWrapperTest,
 # PynwbTutorialTest). Set automatically by the CI matrix for MATLAB releases that
 # use Python 3.9, where pynwb is not supported. Default is 0 (run Python tests).
 #

--- a/.github/workflows/run_pynwb_dev_tests.yml
+++ b/.github/workflows/run_pynwb_dev_tests.yml
@@ -66,7 +66,7 @@ jobs:
             setenv("SKIP_NWBINSPECTOR_TEST", "0")
             pyenv("ExecutionMode", "OutOfProcess");
             results = nwbtest('ReportOutputFolder', '.', ...
-                'Tag', {'UsesPython', 'UsesPythonWhenAvailable'});
+                'Tag', {'RequiresPython', 'UsesPythonWhenAvailable'});
             assert(~isempty(results), 'No tests ran');
             assertSuccess(results);
 

--- a/nwbtest.m
+++ b/nwbtest.m
@@ -149,18 +149,18 @@ function suite = filterTestsByCompatibility(suite)
     skipExternalFilterTests = ~isempty(skipExternalFilterTests) && logical(str2double(skipExternalFilterTests));
 
     if skipPythonTests
-        suite = suite.selectIf(~HasTag('UsesPython'));
+        suite = suite.selectIf(~HasTag('RequiresPython'));
     end
 
     if skipExternalFilterTests
-        suite = suite.selectIf(~HasTag('UsesDynamicallyLoadedFilters'));
+        suite = suite.selectIf(~HasTag('RequiresDynamicallyLoadedFilters'));
     end
 
     % Filter out tests testing dynamically loaded filters. Using
     % dynamically loaded filters is only supported in MATLAB R2022a and
     % newer
     if ~exist("isMATLABReleaseOlderThan", "file") || isMATLABReleaseOlderThan('R2022a')
-        suite = suite.selectIf(~HasTag('UsesDynamicallyLoadedFilters'));
+        suite = suite.selectIf(~HasTag('RequiresDynamicallyLoadedFilters'));
         % Manually skip test for "dynamically loaded filters" tutorial
         isDynamicLoadedFiltersTutorial = contains({suite.Name}, "tutorialFile=dynamically_loaded_filters_mlx");
         suite(isDynamicLoadedFiltersTutorial) = [];


### PR DESCRIPTION
## Problem
The current test tag names are misleading — they do not say what the tags do.

## Solution
Rename the excluding tags to a `Requires` prefix:

| Before | After |
|---|---|
| `UsesPython` | `RequiresPython` |
| `UsesDynamicallyLoadedFilters` | `RequiresDynamicallyLoadedFilters` |

`UsesPythonWhenAvailable` is unchanged. The convention is now that a `Requires` prefix means `nwbtest` drops the test when the dependency is missing, so a test that degrades gracefully on its own must not carry one. Documented in `+tests/README.md`.

It also makes the exclusion in `filterTestsByCompatibility` state its own reason:

```matlab
suite = suite.selectIf(~HasTag('RequiresPython'));
```

No behaviour change. The tags are internal to the test suite and are referenced only by `nwbtest.m`, the test classes, and the weekly `PyNWB dev branch compatibility` workflow.

Follows #873, which introduced `UsesPythonWhenAvailable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

