### PR TITLE
fix(io): write compound datasets that have no rows

### DIFF
--- a/+io/writeCompound.m
+++ b/+io/writeCompound.m
@@ -31,37 +31,28 @@ function writeCompound(fid, fullpath, data, varargin)
     forceArray = any(strcmp('forceArray', varargin));
     forceMatrix = any(strcmp('forceMatrix', varargin));
 
-    %convert to a struct
+    % Normalize the input to a scalar struct holding one column per field,
+    % taking the row count from the input.
     if istable(data)
-        data = table2struct(data);
-    elseif isa(data, 'containers.Map')
-        names = keys(data);
-        vals = values(data, names);
-
-        s = struct();
-        for i=1:length(names)
-            s.(misc.str2validName(names{i})) = vals{i};
+        numrows = height(data);
+        data = tableToColumnStruct(data);
+    elseif isstruct(data) && ~isscalar(data)
+        numrows = numel(data);
+        data = structArrayToColumnStruct(data);
+    else
+        if isa(data, 'containers.Map')
+            data = mapToColumnStruct(data);
         end
-        data = s;
+        numrows = scalarStructNumRows(data);
     end
 
-    %convert to scalar struct
     names = fieldnames(data);
     if isempty(names)
-        numrows = 0;
-    elseif isscalar(data)
-        if ischar(data.(names{1}))
-            numrows = 1;
-        else
-            numrows = length(data.(names{1}));
-        end
-    else
-        numrows = length(data);
-        s = struct();
-        for i=1:length(names)
-            s.(names{i}) = {data.(names{i})};
-        end
-        data = s;
+        error('NWB:WriteCompound:NoFields', ...
+            ['Cannot write the compound dataset "%s" because the data has no ' ...
+            'fields, and a compound type needs at least one member. Provide a ' ...
+            'table with at least one column, a struct with at least one field, ' ...
+            'or a containers.Map with at least one key.'], fullpath)
     end
 
     %check for references and construct tid.
@@ -170,4 +161,74 @@ function writeCompound(fid, fullpath, data, varargin)
     H5D.write(did, tid, sid, sid, 'H5P_DEFAULT', data);
     H5D.close(did);
     H5S.close(sid);
+end
+
+function s = tableToColumnStruct(data)
+% tableToColumnStruct - Convert a table to a scalar struct of columns.
+    if height(data) == 0
+        s = zeroRowTableToColumnStruct(data);
+    else
+        s = structArrayToColumnStruct(table2struct(data));
+    end
+end
+
+function s = zeroRowTableToColumnStruct(data)
+% zeroRowTableToColumnStruct - Convert a table with no rows to a scalar struct
+% of empty columns.
+%
+% Each compound member takes its type from the class of its column, and
+% table2struct loses those classes for a zero-row table, so the columns are
+% read off the table directly. Numeric and logical columns keep their class.
+% Every other column is carried as an empty cellstr, giving it the variable
+% length string member type, which is the type a text column gets for a table
+% with rows. Classes that cannot be typed from an empty value, such as object
+% references, therefore also write as strings.
+    s = struct();
+    variableNames = data.Properties.VariableNames;
+    for iVariable = 1:numel(variableNames)
+        column = data{:, iVariable};
+        if ~isnumeric(column) && ~islogical(column)
+            column = cell(0, 1);
+        end
+        s.(variableNames{iVariable}) = column;
+    end
+end
+
+function s = structArrayToColumnStruct(data)
+% structArrayToColumnStruct - Gather a struct array into a scalar struct whose
+% fields each hold that field's column of values.
+    s = struct();
+    names = fieldnames(data);
+    for iName = 1:numel(names)
+        s.(names{iName}) = {data.(names{iName})};
+    end
+end
+
+function s = mapToColumnStruct(data)
+% mapToColumnStruct - Convert a containers.Map to a scalar struct of columns.
+    s = struct();
+    names = keys(data);
+    vals = values(data, names);
+    for iName = 1:numel(names)
+        s.(misc.str2validName(names{iName})) = vals{iName};
+    end
+end
+
+function numrows = scalarStructNumRows(data)
+% scalarStructNumRows - Number of rows a scalar struct describes.
+%
+% A scalar struct holds either a single row of values or one column per field.
+% The two are told apart by the first field: text is a single value, anything
+% else is a column whose length is the row count.
+    names = fieldnames(data);
+    if isempty(names)
+        numrows = 0;
+        return
+    end
+    firstColumn = data.(names{1});
+    if ischar(firstColumn)
+        numrows = 1;
+    else
+        numrows = length(firstColumn);
+    end
 end

--- a/+io/writeCompound.m
+++ b/+io/writeCompound.m
@@ -27,23 +27,22 @@ function writeCompound(fid, fullpath, data, varargin)
 %   Example:
 %     io.writeCompound(fid, '/group/dataset', data);
 
-
     forceArray = any(strcmp('forceArray', varargin));
     forceMatrix = any(strcmp('forceMatrix', varargin));
 
     % Normalize the input to a scalar struct holding one column per field,
     % taking the row count from the input.
     if istable(data)
-        numrows = height(data);
+        numRows = height(data);
         data = tableToColumnStruct(data);
     elseif isstruct(data) && ~isscalar(data)
-        numrows = numel(data);
+        numRows = numel(data);
         data = structArrayToColumnStruct(data);
     else
         if isa(data, 'containers.Map')
             data = mapToColumnStruct(data);
         end
-        numrows = scalarStructNumRows(data);
+        numRows = scalarStructNumRows(data);
     end
 
     names = fieldnames(data);
@@ -124,10 +123,10 @@ function writeCompound(fid, fullpath, data, varargin)
     end
 
     try
-        if numrows == 1 && ~(forceArray || forceMatrix)
+        if numRows == 1 && ~(forceArray || forceMatrix)
             sid = H5S.create('H5S_SCALAR');
         else
-            sid = H5S.create_simple(1, numrows, []);
+            sid = H5S.create_simple(1, numRows, []);
         end
         did = H5D.create(fid, fullpath, tid, sid, 'H5P_DEFAULT');
     catch ME
@@ -138,7 +137,7 @@ function writeCompound(fid, fullpath, data, varargin)
             [~, edit_dims, ~] = H5S.get_simple_extent_dims(edit_sid);
             layout = H5P.get_layout(create_plist);
             is_chunked = layout == H5ML.get_constant_value('H5D_CHUNKED');
-            is_same_dims = all(edit_dims == numrows);
+            is_same_dims = all(edit_dims == numRows);
 
             if ~is_same_dims
                 if is_chunked

--- a/+tests/+unit/+io/WriteTest.m
+++ b/+tests/+unit/+io/WriteTest.m
@@ -95,18 +95,20 @@ classdef WriteTest < matlab.unittest.TestCase
         end
         
         function testWriteCompoundMap(testCase)
-            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
             fid = H5F.create('test.h5');
             data = containers.Map({'a', 'b'}, 1:2);
             io.writeCompound(fid, '/map_data', data)
             H5F.close(fid);
+
+            readData = h5read('test.h5', '/map_data');
+            testCase.verifyEqual(readData.a, 1)
+            testCase.verifyEqual(readData.b, 2)
         end
         
         function testWriteCompoundWithoutFields(testCase)
             % A compound type needs at least one member, so data carrying no
             % fields cannot be written at all. Every input kind is normalized
             % before the check, so all three reach it.
-            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
             fid = H5F.create('test.h5');
             inputs = {struct, table(), containers.Map};
             for iInput = 1:numel(inputs)
@@ -169,16 +171,16 @@ classdef WriteTest < matlab.unittest.TestCase
         end
 
         function testWriteCompoundScalar(testCase)
-            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
             fid = H5F.create('test.h5');
             data = struct('a','b');
-            io.writeCompound(fid, '/map_data', data)
+            io.writeCompound(fid, '/scalar_data', data)
             H5F.close(fid);
+
+            info = h5info('test.h5', '/scalar_data');
+            testCase.verifyEqual(info.Dataspace.Type, 'scalar')
         end
 
-        function testWriteCompoundNonScalar(testCase)
-            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
-            
+        function testWriteCompoundNonScalar(testCase)            
             numRows = 5;
             numericVector = rand(numRows, 1);
             charVector = char(randi([65 90], numRows, 1));
@@ -186,8 +188,12 @@ classdef WriteTest < matlab.unittest.TestCase
             data = table(numericVector, charVector);
                         
             fid = H5F.create('test.h5');
-            io.writeCompound(fid, '/map_data', data)
+            io.writeCompound(fid, '/nonscalar_data', data)
             H5F.close(fid);
+            
+            info = h5info('test.h5', '/nonscalar_data');
+            testCase.verifyEqual(info.Dataspace.Type, 'simple')
+            testCase.verifyEqual(info.Dataspace.Size, numRows)
         end
 
         function testWriteCompoundOverWrite(testCase)

--- a/+tests/+unit/+io/WriteTest.m
+++ b/+tests/+unit/+io/WriteTest.m
@@ -102,16 +102,72 @@ classdef WriteTest < matlab.unittest.TestCase
             H5F.close(fid);
         end
         
-        function testWriteCompoundEmpty(testCase)
+        function testWriteCompoundWithoutFields(testCase)
+            % A compound type needs at least one member, so data carrying no
+            % fields cannot be written at all. Every input kind is normalized
+            % before the check, so all three reach it.
             testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
             fid = H5F.create('test.h5');
-            data = struct;
-            testCase.verifyError(...
-                @(varargin) io.writeCompound(fid, '/map_data', data), ...
-                'MATLAB:imagesci:hdf5lib:libraryError')
+            inputs = {struct, table(), containers.Map};
+            for iInput = 1:numel(inputs)
+                testCase.verifyError(...
+                    @(varargin) io.writeCompound(fid, '/no_fields', inputs{iInput}), ...
+                    'NWB:WriteCompound:NoFields')
+            end
             H5F.close(fid);
         end
         
+        function testWriteCompoundZeroRowTableKeepsColumnTypes(testCase)
+            % A zero-row table still has to write each column with its own
+            % type. table2struct cannot express that, so writeCompound reads
+            % the columns directly in this case.
+            fid = H5F.create('test.h5');
+            data = table(uint32.empty(0, 1), cell(0, 1), zeros(0, 1), false(0, 1), ...
+                'VariableNames', {'index', 'name', 'value', 'flag'});
+            io.writeCompound(fid, '/empty_data', data, 'forceArray')
+            H5F.close(fid);
+
+            info = h5info('test.h5', '/empty_data');
+            testCase.verifyEqual(info.Dataspace.Size, 0)
+            memberTypes = {info.Datatype.Type.Member.Datatype};
+            testCase.verifyEqual(memberTypes{1}.Class, 'H5T_INTEGER')
+            testCase.verifyEqual(memberTypes{2}.Class, 'H5T_STRING')
+            testCase.verifyEqual(memberTypes{3}.Class, 'H5T_FLOAT')
+            testCase.verifyEqual(memberTypes{4}.Class, 'H5T_ENUM')
+
+            readData = h5read('test.h5', '/empty_data');
+            testCase.verifyClass(readData.index, 'uint32')
+            testCase.verifyEmpty(readData.index)
+        end
+
+        function testWriteCompoundZeroRowTableAcceptsEveryColumnClass(testCase)
+            % A member type can only be derived from an empty column for some
+            % classes. The rest fall back to the string member type they were
+            % already given, rather than erroring. Each column is placed first
+            % because the row count is read off the first field.
+            columns = { ...
+                'chardata',    char.empty(0, 1); ...
+                'stringdata',  string.empty(0, 1); ...
+                'cellstrdata', cell(0, 1); ...
+                'int64data',   int64.empty(0, 1); ...
+                'singledata',  single.empty(0, 1)};
+
+            for iColumn = 1:size(columns, 1)
+                columnName = columns{iColumn, 1};
+                data = table(columns{iColumn, 2}, uint32.empty(0, 1), ...
+                    'VariableNames', {columnName, 'idx'});
+
+                fileName = sprintf('%s.h5', columnName);
+                fid = H5F.create(fileName);
+                io.writeCompound(fid, '/d', data, 'forceArray')
+                H5F.close(fid);
+
+                info = h5info(fileName, '/d');
+                testCase.verifyEqual(info.Dataspace.Size, 0, ...
+                    sprintf('A zero-row "%s" column should write no rows.', columnName))
+            end
+        end
+
         function testWriteCompoundScalar(testCase)
             testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture)
             fid = H5F.create('test.h5');

--- a/+types/+untyped/MetaClass.m
+++ b/+types/+untyped/MetaClass.m
@@ -254,7 +254,11 @@ classdef MetaClass < handle & matlab.mixin.CustomDisplay
 
             for i = 1:numel(requiredProps)
                 thisPropName = requiredProps{i};
-                if isempty(obj.(thisPropName))
+                propValue = obj.(thisPropName);
+                % A row-less table is a value rather than an omission: a
+                % compound dataset that holds no rows, such as the tables of a
+                % HERD without references, still has to be written.
+                if isempty(propValue) && ~istable(propValue)
                     missingRequiredProps{end+1} = thisPropName; %#ok<AGROW>
                 end
             end


### PR DESCRIPTION
## Motivation

**Background** — This surfaced while adding a user-facing API for HERD, the type that records which external entities the terms in a file refer to. A HERD holds six compound datasets that the schema all marks required, so a file whose HERD has no external references yet holds six empty ones. That is a state a file legitimately reaches: asking a file for its external resources attaches a HERD before anything has been added to it, and PyNWB writes an empty HERD for the same sequence. The cross-reference columns of those tables are `uint32`, which is how the mistyping below surfaced. Writing and reading such a dataset were both affected; this PR is the write half, and #880 is the read half.

**Problem** — A compound dataset with no rows could not be written correctly. Every column was written as a string on disk regardless of what it held, so an integer column read back as text, and the same column changed member type depending on whether the table happened to be empty. A compound dataset holding a table with no rows also counted as a missing required property, so a file containing one could not be exported at all.

Separately, data carrying no fields at all reported an HDF5 error from several call layers down rather than saying what was wrong.

**Solution** — Take the row count from the input, and read the columns of a zero-row table directly so each keeps its own type. Treat a zero-row table as a value rather than an omission when checking required properties, and name the no-fields case in its own error.

## What changed

- A compound dataset written from a table with no rows gives each column its own member type, the same type that column gets when the table has rows.
- A type whose required dataset holds a table with no rows exports instead of erroring.
- Data with no fields raises `NWB:WriteCompound:NoFields` instead of `MATLAB:imagesci:hdf5lib:libraryError` / "H5Tcreate size must be positive". A field-less struct, a column-less table and an empty `containers.Map` all report it.

Text columns are unaffected: a text column is written as a variable length string whether or not the table has rows. This covers the write path only. Reading a zero-row compound dataset back returns an empty array without member names, which #880 fixes.

<details><summary>Implementation notes</summary>

The row count used to be read back off the normalized struct, which cannot express it: a scalar struct is written either as a single row of values or as one column per field, and the two were told apart by checking whether the first field held text. Normalizing a zero-row table into that same shape gave a scalar struct a third meaning. It is now taken from the input, and each input kind is normalized in its own branch, so the text check applies only to a scalar struct or `containers.Map` — the one input that really is ambiguous.

`table2struct` returns a 0x1 struct array for a zero-row table, and the per-column classes cannot be recovered from it, so the columns are read off the table directly. Numeric and logical columns keep their class; every other column is carried as an empty cellstr, which is the member type a text column already gets. Classes that cannot be typed from an empty value, such as object references, therefore also write as strings.

`types.untyped.MetaClass/checkRequiredProps` used a bare `isempty` test, which is true for a table with no rows. It now excludes tables, so an explicitly typed empty table counts as a value.

</details>

## Examples

### Member types of a zero-row compound dataset

```matlab
fid = H5F.create('probe.h5');
emptyTable = table(uint32.empty(0, 1), cell(0, 1), ...
    'VariableNames', {'files_idx', 'object_id'});
io.writeCompound(fid, '/empty', emptyTable, 'forceArray');
H5F.close(fid);

info = h5info('probe.h5', '/empty');
for iMember = 1:numel(info.Datatype.Type.Member)
    member = info.Datatype.Type.Member(iMember);
    fprintf('%-12s %s\n', member.Name, member.Datatype.Class);
end
```

**Before**

```
files_idx    H5T_STRING
object_id    H5T_STRING
```

**After**

```
files_idx    H5T_INTEGER
object_id    H5T_STRING
```

The same column with rows already wrote as `H5T_INTEGER`, so the member type no longer depends on whether the table is empty.

### Exporting a type whose compound datasets hold no rows

Building a `types.hdmf_common.HERD` whose six tables are all empty, assigning it to `nwb.general_external_resources`, then calling `nwbExport(nwb, 'empty_herd.nwb')`:

**Before**

```
Error using nwbExport
The following required properties are missing for instance for type "types.hdmf_common.Data" at file location "/general/external_resources/entities":
    data
```

**After**

```
nwbExport succeeded
```

### Writing data that has no fields

```matlab
fid = H5F.create('probe.h5');
io.writeCompound(fid, '/no_fields', struct);
```

**Before**

```
Error using matlab.internal.sci.hdf5lib2
The HDF5 library encountered an error and produced the following stack trace information:

 H5Tcreate    size must be positive
```

**After**

```
Cannot write the compound dataset "/no_fields" because the data has no fields, and a compound
type needs at least one member. Provide a table with at least one column, a struct with at least
one field, or a containers.Map with at least one key.
```

## How to test

```matlab
workingFolder = tempname; mkdir(workingFolder); cd(workingFolder);

% Member types survive for a table with no rows
fid = H5F.create('probe.h5');
emptyTable = table(uint32.empty(0, 1), cell(0, 1), ...
    'VariableNames', {'files_idx', 'object_id'});
io.writeCompound(fid, '/empty', emptyTable, 'forceArray');
H5F.close(fid);
info = h5info('probe.h5', '/empty');
disp({info.Datatype.Type.Member.Name})
disp(cellfun(@(x) x.Class, {info.Datatype.Type.Member.Datatype}, 'UniformOutput', false))

% Data with no fields names the problem
fid2 = H5F.create('nofields.h5');
try
    io.writeCompound(fid2, '/no_fields', struct);
catch ME
    disp(ME.identifier)
end
H5F.close(fid2);

% And a zero-row compound dataset can be exported
nwb = NwbFile('session_description', 'demo', 'identifier', 'DEMO', ...
    'session_start_time', '2018-12-02T12:57:27.371444-08:00');
herd = types.hdmf_common.HERD();
herd.keys = types.hdmf_common.Data('data', table(cell(0,1), 'VariableNames', {'key'}));
herd.files = types.hdmf_common.Data('data', table(cell(0,1), 'VariableNames', {'file_object_id'}));
herd.entities = types.hdmf_common.Data('data', table(cell(0,1), cell(0,1), ...
    'VariableNames', {'entity_id', 'entity_uri'}));
herd.objects = types.hdmf_common.Data('data', table(uint32.empty(0,1), cell(0,1), cell(0,1), ...
    cell(0,1), cell(0,1), 'VariableNames', ...
    {'files_idx', 'object_id', 'object_type', 'relative_path', 'field'}));
herd.object_keys = types.hdmf_common.Data('data', table(uint32.empty(0,1), uint32.empty(0,1), ...
    'VariableNames', {'objects_idx', 'keys_idx'}));
herd.entity_keys = types.hdmf_common.Data('data', table(uint32.empty(0,1), uint32.empty(0,1), ...
    'VariableNames', {'entities_idx', 'keys_idx'}));
nwb.general_external_resources = herd;
nwbExport(nwb, 'empty_herd.nwb');
```

Unit test:

```matlab
nwbtest('Name', 'tests.unit.io.WriteTest')
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

