### PR TITLE
test(schema): use explicit shapes in testMultipleNullShapesDataset

### DIFF
--- a/+tests/+unit/+schema/MultipleShapesTest.m
+++ b/+tests/+unit/+schema/MultipleShapesTest.m
@@ -39,15 +39,22 @@ classdef MultipleShapesTest < tests.unit.abstract.SchemaTest
         end
         
         function testMultipleNullShapesDataset(testCase)
+            % MultiNullShapeDataset accepts one-dimensional data of any length
+            % and two-dimensional data of any size. Cover a scalar, a column
+            % vector, a row vector and a matrix; assigning a shape the type does
+            % not accept errors on assignment and fails the test.
+            validShapes = {[1, 1], [23, 1], [1, 23], [7, 5]};
+
             mnsd = types.mss.MultiNullShapeDataset;
-            randiMax = intmax('int8');
-            for i=1:100
-                if rand() > 0.5
-                    mnsd.data = rand(randi(randiMax), 1);
-                else
-                    mnsd.data = rand(randi(randiMax), randi(randiMax));
-                end
+            for iShape = 1:numel(validShapes)
+                mnsd.data = rand(validShapes{iShape});
             end
+
+            % Export a matrix. One-dimensional data is written as a rank-1
+            % dataset and read back as a column, so a row vector would not
+            % compare equal after the round trip (see the dimension ordering
+            % concept documentation).
+            mnsd.data = rand(7, 5);
             testCase.roundabout(mnsd);
         end
         


### PR DESCRIPTION
## Motivation

**Problem** — The prepare release workflow runs the test suite across every MATLAB release crossed with every platform, 36 jobs in total. `tests.unit.schema.MultipleShapesTest/testMultipleNullShapesDataset` failed on exactly one of them, R2022a on `windows-latest`, and passed on the other 35. The failure reported a shape mismatch between the exported and the re-read dataset:

```
Actual size:
    50     1
Expected size:
     1    50
```

The test assigned 100 randomly shaped arrays to a `MultiNullShapeDataset` and exported whichever one the last iteration happened to produce. Occasionally that is a row vector, which cannot survive a round trip: MatNWB writes any vector as a rank-1 HDF5 dataset, and MATLAB reads a rank-1 dataset back as a column. MATLAB resets its random number generator only at session start, so the shape reached on iteration 100 depends on how many random numbers the tests before it drew. A release-and-platform combination that draws a different number of them lands on a different shape, which is why the failure was confined to a single matrix job and could not be reproduced from the others.

**Solution** — Assign an explicit list of shapes instead of random ones, and export a fixed matrix. Every matrix job now exercises the same shapes, so the test either passes everywhere or fails everywhere.

## What changed

- `testMultipleNullShapesDataset` assigns four named shapes — a scalar, a column vector, a row vector and a matrix — in place of 100 random ones.
- The value handed to the round trip is a fixed `7x5` matrix rather than whatever the loop left behind.
- The row vector case, which produced the original failure, is now covered on every run instead of appearing at random.

<details><summary>Implementation notes</summary>

The orientation loss is intended and is documented under [dimension ordering](docs/source/pages/concepts/dimension_ordering.rst): one-dimensional data has to be rank-1 in the file to stay readable by other NWB implementations, and MATLAB has no rank-1 array type to read it back into.

```matlab
fid = H5F.create(tmp, 'H5F_ACC_TRUNC', 'H5P_DEFAULT', 'H5P_DEFAULT');
io.writeDataset(fid, '/rowvec', rand(1, 50));
H5F.close(fid);
```

```
written in MATLAB as : [1 50]
dataspace in the file: 50  (rank 1)
read back in MATLAB  : [50 1]
```

Assigning a row vector is still valid for the type — the schema shape is `[[null], [null, null]]` — so the loop keeps covering it. Only the exported value had to become orientation-stable.

</details>

## Examples

### The shape handed to the round trip

Standing in for the random numbers drawn by earlier tests with a variable offset into the default stream shows what the exported shape depended on. Offsets 82 and 284 both end on a row vector.

**Before**

```matlab
randiMax = intmax('int8');
for i = 1:100
    if rand() > 0.5
        data = rand(randi(randiMax), 1);
    else
        data = rand(randi(randiMax), randi(randiMax));
    end
end
```

```
  stream offset    0 -> [3 88]
  stream offset   82 -> [1 113]
  stream offset  284 -> [1 44]
```

**After**

```matlab
validShapes = {[1, 1], [23, 1], [1, 23], [7, 5]};
for iShape = 1:numel(validShapes)
    data = rand(validShapes{iShape});
end
data = rand(7, 5);
```

```
  stream offset    0 -> [7 5]
  stream offset   82 -> [7 5]
  stream offset  284 -> [7 5]
```

Sweeping 2001 offsets, 8 of them end on a row vector. That is the roughly 1-in-250 chance the test carried on every job.

## How to test

```matlab
nwbtest('Name', 'tests.unit.schema.MultipleShapesTest')
```

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
