### PR TITLE
ci: run R2026a macOS release tests on Apple silicon

### DIFF
--- a/.github/workflows/configurations/matlab_release_matrix_strategy.yml
+++ b/.github/workflows/configurations/matlab_release_matrix_strategy.yml
@@ -1,44 +1,61 @@
+# Test matrix configuration, one entry per supported MATLAB release.
+#
+# macos-runner selects the macOS runner image for a release. MATLAB is not
+# released for Intel Macs as of R2026a, so R2026a and later must be tested on
+# an Apple silicon runner. See:
+# https://www.mathworks.com/support/requirements/platform-road-map.html
 - matlab-version: R2021a
   python-version: '3.9'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '1'
   skip-nwbinspector-test: '1'
 - matlab-version: R2021b
   python-version: '3.9'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '1'
   skip-nwbinspector-test: '1'
 - matlab-version: R2022a
   python-version: '3.9'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '1'
   skip-nwbinspector-test: '1'
 - matlab-version: R2022b
   python-version: '3.10'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'
 - matlab-version: R2023a
   python-version: '3.10'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'
 - matlab-version: R2023b
   python-version: '3.11'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'
 - matlab-version: R2024a
   python-version: '3.11'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'
 - matlab-version: R2024b
   python-version: '3.12'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'
 - matlab-version: R2025a
   python-version: '3.12'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'
 - matlab-version: R2025b
   python-version: '3.12'
+  macos-runner: macos-15-intel
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'
 - matlab-version: R2026a
   python-version: '3.13'
+  macos-runner: macos-latest
   skip-pynwb-tests: '0'
   skip-nwbinspector-test: '0'

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -38,11 +38,16 @@ jobs:
         run: |
           config=.github/workflows/configurations/matlab_release_matrix_strategy.yml
 
-          # Cross every MATLAB release with every platform
+          # One job per MATLAB release and platform. The macOS runner is
+          # release-specific, so the combinations are listed explicitly instead
+          # of being generated as a cross product of `os` and `matlab-version`.
           matrix=$(yq -o=json '{
-              "os": ["windows-latest", "ubuntu-latest", "macos-15-intel"],
-              "matlab-version": [.[].matlab-version],
-              "include": .
+              "include": [
+                .[] as $release
+                  | ["windows-latest", "ubuntu-latest", $release.macos-runner]
+                  | .[] as $os
+                  | ($release * {"os": $os} | del(.macos-runner))
+              ]
             }' "$config" | tr -d '\n')
 
           # Release list for the 'tested with' badge, e.g. "R2021a | R2021b"


### PR DESCRIPTION
## Motivation

**Background** — R2026a was added to the release test matrix, which runs every supported MATLAB release on Windows, Ubuntu, and macOS.

**Problem** — MathWorks does not release MATLAB for Macs with Intel processors as of R2026a ([platform road map](https://www.mathworks.com/support/requirements/platform-road-map.html)). The macOS leg of the release matrix runs on `macos-15-intel`, so the R2026a job fails while installing MATLAB. `update_version` depends on `run_tests`, so that single failure blocks the version bump, the tag, the badges, and the draft release for the entire run.

**Solution** — Choose the macOS runner per MATLAB release instead of using one runner for all of them. R2026a is tested on an Apple silicon runner; earlier releases keep running on the Intel runner.

## What changed

- The release matrix tests R2026a on macOS again, now on `macos-latest` (Apple silicon).
- Each entry in the matrix configuration declares the macOS runner its release uses, so moving a future release off the Intel runner is a one-line change.
- Job count, job keys, and the `tested with` badge string are unchanged: 11 releases across 3 platforms, 33 jobs.

<details><summary>Implementation notes</summary>

`matlab_release_matrix_strategy.yml` gains a `macos-runner` field per release. `prepare_release.yml` builds the matrix as an explicit `include` list — each release crossed with `windows-latest`, `ubuntu-latest`, and its own `macos-runner` — instead of a cross product of a fixed `os` array with `matlab-version`. `macos-runner` is deleted from each generated job so it does not appear as an unused matrix variable.

`matlab-actions/setup-matlab@v3` handles the Apple silicon requirements under its default `install-system-dependencies: auto`: it installs the JRE that native Apple silicon MATLAB requires and fetches the `maca64` build of `matlab-batch` used by `run-command`.

`run_tests.yml` reads the same configuration file and passes it through unchanged, so its jobs now carry a `macos-runner` key they do not use. Those jobs run on Ubuntu only, so the extra key has no effect.

</details>

## Examples

The R2026a job on `macos-15-intel` in the most recent release run:

```
Installing with the following parameters:
--destination=/Users/runner/hostedtoolcache/MATLAB/2026.1.999/x64/MATLAB.app
--release=R2026a
--products=MATLAB
---------------------------------------------
...
Starting install
Products will be installed to: /Users/runner/hostedtoolcache/MATLAB/2026.1.999/x64/MATLAB.app
Finished install
Completing setup...
Error: Installation failed.
##[error]Error: Script exited with non-zero code 255
```

R2026a passed on `windows-latest` and `ubuntu-latest` in the same run, and every other release installed and tested normally on `macos-15-intel`.

The macOS jobs the matrix produces after this change:

```
R2021a macos-15-intel
R2021b macos-15-intel
R2022a macos-15-intel
R2022b macos-15-intel
R2023a macos-15-intel
R2023b macos-15-intel
R2024a macos-15-intel
R2024b macos-15-intel
R2025a macos-15-intel
R2025b macos-15-intel
R2026a macos-latest
```

## How to test

Generate the matrix the way the `set_matrix` job does and list the platforms per release:

```bash
yq -o=json '{"include": [.[] as $release | ["windows-latest", "ubuntu-latest", $release.macos-runner] | .[] as $os | ($release * {"os": $os} | del(.macos-runner))]}' \
  .github/workflows/configurations/matlab_release_matrix_strategy.yml \
  | jq -r '.include[] | "\(.["matlab-version"]) \(.os)"'
```

The full check is a `Prepare release` workflow dispatch, where the R2026a macOS job installs MATLAB and runs the test suite instead of failing during installation.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
