### PR TITLE
ci: fix and harden the prepare release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -9,6 +9,12 @@ on:
         required: true
         type: string
 
+# Releases from the same ref run one at a time. Rehearsals on a branch use a
+# separate group, so they never queue behind or block a release from main.
+concurrency:
+  group: prepare-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   validate_version:
     runs-on: ubuntu-latest
@@ -21,6 +27,39 @@ jobs:
             exit 1
           fi
           echo "Version '$version' is valid."
+
+      # Reject an already released version now, rather than after the test
+      # matrix has run and the version bump has been pushed to main. Rehearsals
+      # push nothing, so they are not subject to this check.
+      - name: Check version is not already released
+        if: github.ref == 'refs/heads/main'
+        run: |
+          version="${{ github.event.inputs.version }}"
+          remote="https://github.com/${{ github.repository }}.git"
+
+          # An annotated tag lists both the tag object and, under ^{}, the commit
+          # it marks. Prefer the latter, which is what the tag step compares.
+          tagged=$(git ls-remote --tags "$remote" "refs/tags/v$version^{}" | awk '{print $1}')
+          if [[ -z "$tagged" ]]; then
+            tagged=$(git ls-remote --tags "$remote" "refs/tags/v$version" | awk '{print $1}')
+          fi
+
+          if [[ -z "$tagged" ]]; then
+            echo "Tag 'v$version' does not exist yet."
+            exit 0
+          fi
+
+          # A tag on the current tip of main is left over from a run that failed
+          # after tagging. Allow it, so that run can be retried.
+          main_tip=$(git ls-remote "$remote" refs/heads/main | awk '{print $1}')
+          if [[ "$tagged" == "$main_tip" ]]; then
+            echo "Tag 'v$version' already marks the tip of main; treating this as a retry."
+            exit 0
+          fi
+
+          echo "Error: version $version is already released. Tag 'v$version' marks $tagged."
+          echo "Choose a new version, or delete the tag if it is left over from a failed run."
+          exit 1
 
   set_matrix:
     name: Set test matrix
@@ -128,6 +167,12 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs: [run_tests]
+    # Stated explicitly so the job keeps working if the repository default for
+    # GITHUB_TOKEN is ever reduced to read-only. The report action creates a
+    # check run; pull-requests write is only needed with `comment: true`.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -147,11 +192,35 @@ jobs:
     name: Create new draft release for given version
     runs-on: ubuntu-latest
     needs: [run_tests, set_matrix]
+    permissions:
+      contents: write
+    env:
+      # Only a dispatch from main publishes. Dispatching from another branch
+      # rehearses the release against that branch: every step runs, but nothing
+      # is pushed and no release is created.
+      IS_RELEASE: ${{ github.ref == 'refs/heads/main' }}
     steps:
+      - name: Report release mode
+        run: |
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            echo "Publishing v${{ inputs.version }} from \`main\`." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Rehearsal only"
+              echo
+              echo "Dispatched from \`${{ github.ref_name }}\` rather than \`main\`, so this run publishes nothing:"
+              echo "no commit to main, no tag, no badge push and no release."
+              echo "Dispatch from \`main\` to publish."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Checkout repository using deploy key
         uses: actions/checkout@v6
         with:
-          ref: refs/heads/main
+          # A rehearsal checks out the branch it was dispatched from, so it
+          # exercises that branch's scripts rather than the ones on main. A
+          # release is dispatched from main, so this resolves to refs/heads/main.
+          ref: ${{ github.ref }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Update Contents.m file
@@ -173,6 +242,14 @@ jobs:
           # Extract the content after the header from the current Contents.m file
           content=$(awk '/^% -{10,}/{flag=1;next} flag{print}' Contents.m)
           
+          # An empty result means the separator was not found. Writing the file
+          # at this point would replace the whole listing with just the header.
+          if [[ -z "$content" ]]; then
+            echo "Error: found no content after the header separator in Contents.m."
+            echo "The separator line (% followed by 10 or more dashes) may have changed."
+            exit 1
+          fi
+          
           # Combine new header with existing content
           echo "$header" > Contents.m
           echo "$content" >> Contents.m
@@ -192,6 +269,11 @@ jobs:
 
           git add Contents.m
           git commit -m "Update version number in Contents.m"
+
+          if [[ "$IS_RELEASE" != "true" ]]; then
+            echo "Rehearsal: committed locally, not pushing to main."
+            exit 0
+          fi
 
           # Let a rejected push fail the job. main having moved during the test
           # run means the release needs a human decision, not a silent retry.
@@ -247,6 +329,12 @@ jobs:
           fi
 
           git tag -a "$tag" -m "Release $tag"
+
+          if [[ "$IS_RELEASE" != "true" ]]; then
+            echo "Rehearsal: tagged locally, not pushing $tag."
+            exit 0
+          fi
+
           git push origin "$tag"
       
       # Commit the SVG for the MATLAB releases test badge to gh-badges branch
@@ -269,16 +357,24 @@ jobs:
           git config user.email "<>"
 
           # Only proceed with commit and push if changes are detected
-          if [[ -n "$(git status --porcelain .github/badges)" ]]; then
-            git add .github/badges
-            git commit -m "Update badges for release v${{ inputs.version }}"
-            git push
-          else
+          if [[ -z "$(git status --porcelain .github/badges)" ]]; then
             echo "Badges are unchanged; nothing to commit"
+            exit 0
           fi
+
+          git add .github/badges
+          git commit -m "Update badges for release v${{ inputs.version }}"
+
+          if [[ "$IS_RELEASE" != "true" ]]; then
+            echo "Rehearsal: committed badges locally, not pushing to gh-badges."
+            exit 0
+          fi
+
+          git push
 
       # Create the release
       - name: Create GitHub release
+        if: env.IS_RELEASE == 'true'
         uses: ncipollo/release-action@v1
         with:
           draft: true

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -144,7 +144,7 @@ jobs:
           report_paths: '*/testResults.xml'
 
   update_version:
-    name: Create new draft relase for given version
+    name: Create new draft release for given version
     runs-on: ubuntu-latest
     needs: [run_tests, set_matrix]
     steps:
@@ -178,24 +178,36 @@ jobs:
           echo "$content" >> Contents.m
 
       - name: Commit updated Contents.m file
-        continue-on-error: true
         run: |
           git config user.name "${{ github.workflow }} by ${{ github.actor }}"
           git config user.email "<>"
+
+          # Contents.m is already at this version when a previous run pushed the
+          # bump before failing later on. Skip the commit instead of failing, so
+          # the workflow can be re-run after such a failure.
+          if git diff --quiet -- Contents.m; then
+            echo "Contents.m is already at version ${{ inputs.version }}; nothing to commit."
+            exit 0
+          fi
+
           git add Contents.m
           git commit -m "Update version number in Contents.m"
-          git fetch
-          git push
+
+          # Let a rejected push fail the job. main having moved during the test
+          # run means the release needs a human decision, not a silent retry.
+          git push origin HEAD:refs/heads/main
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12' # Pinned to 3.12 because of pybadges dependencies
+          python-version: '3.12'
 
       - name: Generate tested with badge
         run: |
-          pip install --upgrade setuptools
-          pip install pybadges
+          # pybadges imports pkg_resources at load time, which setuptools no
+          # longer ships as of 82.0. Python 3.12 does not bundle setuptools, so
+          # it has to be installed explicitly and held below that version.
+          pip install "setuptools<82" pybadges
           mkdir -p .github/badges/v${{ inputs.version }}
           python -c "
           from pybadges import badge
@@ -212,18 +224,30 @@ jobs:
           python .github/workflows/scripts/create_nwb_schema_version_badge.py ${{ inputs.version }}
 
       - name: Tag repository with version tag
-        if: always()
         run: |
-          git fetch
+          tag="v${{ inputs.version }}"
 
           git config user.name "${{ github.workflow }} by ${{ github.actor }}"
           git config user.email "<>"
 
-          # Create the tag with a message
-          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}" 
+          git fetch --tags origin
 
-          # Push the new tag to the remote repository
-          git push origin "v${{ inputs.version }}"
+          # A previous run may have pushed the tag before failing further down.
+          # Re-use it when it already marks this commit; refuse when it marks a
+          # different one, so a release is never cut against unexpected code.
+          if existing=$(git rev-list -n 1 "$tag" 2>/dev/null); then
+            if [[ "$existing" == "$(git rev-parse HEAD)" ]]; then
+              echo "Tag $tag already points at $existing; keeping it."
+              exit 0
+            fi
+            echo "Error: tag $tag already exists and points at $existing."
+            echo "This run is releasing $(git rev-parse HEAD)."
+            echo "Delete the tag or choose a new version, then re-run."
+            exit 1
+          fi
+
+          git tag -a "$tag" -m "Release $tag"
+          git push origin "$tag"
       
       # Commit the SVG for the MATLAB releases test badge to gh-badges branch
       - name: Checkout gh-badges branch
@@ -245,12 +269,12 @@ jobs:
           git config user.email "<>"
 
           # Only proceed with commit and push if changes are detected
-          if [[ $(git add .github/badges/* --dry-run | wc -l) -gt 0 ]]; then
-            git add .github/badges/*
+          if [[ -n "$(git status --porcelain .github/badges)" ]]; then
+            git add .github/badges
             git commit -m "Update badges for release v${{ inputs.version }}"
-            git push -f
+            git push
           else
-            echo "Nothing to commit"
+            echo "Badges are unchanged; nothing to commit"
           fi
 
       # Create the release

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -202,21 +202,21 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install badge generator
+        run: pip install anybadge
+
       - name: Generate tested with badge
         run: |
-          # pybadges imports pkg_resources at load time, which setuptools no
-          # longer ships as of 82.0. Python 3.12 does not bundle setuptools, so
-          # it has to be installed explicitly and held below that version.
-          pip install "setuptools<82" pybadges
           mkdir -p .github/badges/v${{ inputs.version }}
           python -c "
-          from pybadges import badge
-          with open('.github/badges/v${{ inputs.version }}/tested_with.svg', 'w') as f:
-              f.write(badge(
-                  left_text='tested with',
-                  right_text='${{ needs.set_matrix.outputs.releases }}',
-                  right_color='green'
-              ))
+          from anybadge import Badge
+          # Explicit hex rather than the 'green' keyword, which anybadge maps to
+          # a brighter shade than earlier releases of this badge used.
+          Badge(
+              label='tested with',
+              value='${{ needs.set_matrix.outputs.releases }}',
+              default_color='#97CA00'
+          ).write_badge('.github/badges/v${{ inputs.version }}/tested_with.svg', overwrite=True)
           "
 
       - name: Generate NWB schema version badge

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -18,10 +18,14 @@ concurrency:
 jobs:
   validate_version:
     runs-on: ubuntu-latest
+    # The dispatch input reaches the shell as an environment variable. Pasting
+    # it into a script with ${{ }} would let its contents be parsed as code.
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
       - name: Check version format
         run: |
-          version="${{ github.event.inputs.version }}"
+          version="$VERSION"
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Input for 'version' ('$version') is not in the expected major.minor.patch format."
             exit 1
@@ -34,7 +38,7 @@ jobs:
       - name: Check version is not already released
         if: github.ref == 'refs/heads/main'
         run: |
-          version="${{ github.event.inputs.version }}"
+          version="$VERSION"
           remote="https://github.com/${{ github.repository }}.git"
 
           # An annotated tag lists both the tag object and, under ^{}, the commit
@@ -199,11 +203,14 @@ jobs:
       # rehearses the release against that branch: every step runs, but nothing
       # is pushed and no release is created.
       IS_RELEASE: ${{ github.ref == 'refs/heads/main' }}
+      # The dispatch input reaches the shell as an environment variable. Pasting
+      # it into a script with ${{ }} would let its contents be parsed as code.
+      VERSION: ${{ inputs.version }}
     steps:
       - name: Report release mode
         run: |
           if [[ "$IS_RELEASE" == "true" ]]; then
-            echo "Publishing v${{ inputs.version }} from \`main\`." >> "$GITHUB_STEP_SUMMARY"
+            echo "Publishing v$VERSION from \`main\`." >> "$GITHUB_STEP_SUMMARY"
           else
             {
               echo "### Rehearsal only"
@@ -235,7 +242,7 @@ jobs:
           year_number=$(date +"%Y")
           
           # Replace placeholders in template
-          header="${template/\{\{version_number\}\}/${{ github.event.inputs.version }}}"
+          header="${template/\{\{version_number\}\}/$VERSION}"
           header="${header/\{\{date_string\}\}/$date_string}"
           header="${header/\{\{year_number\}\}/$year_number}"
           
@@ -263,7 +270,7 @@ jobs:
           # bump before failing later on. Skip the commit instead of failing, so
           # the workflow can be re-run after such a failure.
           if git diff --quiet -- Contents.m; then
-            echo "Contents.m is already at version ${{ inputs.version }}; nothing to commit."
+            echo "Contents.m is already at version $VERSION; nothing to commit."
             exit 0
           fi
 
@@ -285,29 +292,48 @@ jobs:
           python-version: '3.12'
 
       - name: Install badge generator
-        run: pip install anybadge
+        # Pinned so a new anybadge release cannot change the badges, or break
+        # this job, without the pin being updated deliberately.
+        run: pip install anybadge==1.16.0
 
       - name: Generate tested with badge
+        env:
+          RELEASES: ${{ needs.set_matrix.outputs.releases }}
         run: |
-          mkdir -p .github/badges/v${{ inputs.version }}
-          python -c "
+          mkdir -p ".github/badges/v$VERSION"
+          OUT_PATH=".github/badges/v$VERSION/tested_with.svg" python -c "
+          import os
           from anybadge import Badge
           # Explicit hex rather than the 'green' keyword, which anybadge maps to
           # a brighter shade than earlier releases of this badge used.
           Badge(
               label='tested with',
-              value='${{ needs.set_matrix.outputs.releases }}',
+              value=os.environ['RELEASES'],
               default_color='#97CA00'
-          ).write_badge('.github/badges/v${{ inputs.version }}/tested_with.svg', overwrite=True)
+          ).write_badge(os.environ['OUT_PATH'], overwrite=True)
           "
 
       - name: Generate NWB schema version badge
         run: |
-          python .github/workflows/scripts/create_nwb_schema_version_badge.py ${{ inputs.version }}
+          # The latest/ badge should describe the newest release. Re-running for
+          # an older version must not point it backwards. Tags are matched with
+          # and without a leading v, since releases up to 2.9.0 omitted it.
+          highest=$(git ls-remote --tags --refs origin \
+            | sed 's|.*refs/tags/||; s|^v||' \
+            | grep -E '^[0-9]+(\.[0-9]+)+$' \
+            | sort -V | tail -1)
+
+          if [[ -z "$highest" || "$(printf '%s\n%s\n' "$highest" "$VERSION" | sort -V | tail -1)" == "$VERSION" ]]; then
+            echo "$VERSION is the newest release; updating the latest/ badge."
+            python .github/workflows/scripts/create_nwb_schema_version_badge.py "$VERSION" --update-latest
+          else
+            echo "$VERSION is older than $highest; leaving the latest/ badge alone."
+            python .github/workflows/scripts/create_nwb_schema_version_badge.py "$VERSION"
+          fi
 
       - name: Tag repository with version tag
         run: |
-          tag="v${{ inputs.version }}"
+          tag="v$VERSION"
 
           git config user.name "${{ github.workflow }} by ${{ github.actor }}"
           git config user.email "<>"
@@ -346,11 +372,15 @@ jobs:
 
       - name: Push to gh-badges
         run: |
-          mkdir -p gh-badges/.github/badges/v${{ inputs.version }}
-          mkdir -p gh-badges/.github/badges/latest
-          cp .github/badges/v${{ inputs.version }}/tested_with.svg gh-badges/.github/badges/v${{ inputs.version }}/tested_with.svg
-          cp .github/badges/v${{ inputs.version }}/supported_nwb_schema.svg gh-badges/.github/badges/v${{ inputs.version }}/supported_nwb_schema.svg
-          cp .github/badges/latest/supported_nwb_schema.svg gh-badges/.github/badges/latest/supported_nwb_schema.svg
+          mkdir -p "gh-badges/.github/badges/v$VERSION"
+          cp ".github/badges/v$VERSION/tested_with.svg" "gh-badges/.github/badges/v$VERSION/tested_with.svg"
+          cp ".github/badges/v$VERSION/supported_nwb_schema.svg" "gh-badges/.github/badges/v$VERSION/supported_nwb_schema.svg"
+
+          # Only present when this release is the newest one.
+          if [[ -f .github/badges/latest/supported_nwb_schema.svg ]]; then
+            mkdir -p gh-badges/.github/badges/latest
+            cp .github/badges/latest/supported_nwb_schema.svg gh-badges/.github/badges/latest/supported_nwb_schema.svg
+          fi
           cd gh-badges
 
           git config user.name "${{ github.workflow }} by ${{ github.actor }}"
@@ -363,7 +393,7 @@ jobs:
           fi
 
           git add .github/badges
-          git commit -m "Update badges for release v${{ inputs.version }}"
+          git commit -m "Update badges for release v$VERSION"
 
           if [[ "$IS_RELEASE" != "true" ]]; then
             echo "Rehearsal: committed badges locally, not pushing to gh-badges."

--- a/.github/workflows/scripts/create_nwb_schema_version_badge.py
+++ b/.github/workflows/scripts/create_nwb_schema_version_badge.py
@@ -5,7 +5,7 @@ import argparse
 import re
 from pathlib import Path
 
-from pybadges import badge
+from anybadge import Badge
 
 
 def get_schema_version_range(schema_dir: Path) -> tuple[str, str]:
@@ -47,14 +47,12 @@ def create_badge(version: str, min_schema: str, max_schema: str, output_dir: Pat
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / 'supported_nwb_schema.svg'
     
-    badge_svg = badge(
-        left_text='supported NWB schema',
-        right_text=f'{min_schema} - {max_schema}',
-        right_color='Teal'
+    badge = Badge(
+        label='supported NWB schema',
+        value=f'{min_schema} - {max_schema}',
+        default_color='Teal'
     )
-    
-    with open(output_path, 'w') as f:
-        f.write(badge_svg)
+    badge.write_badge(output_path, overwrite=True)
     
     print(f"Badge created: {output_path}")
     print(f"Schema version range: {min_schema} - {max_schema}")

--- a/.github/workflows/scripts/create_nwb_schema_version_badge.py
+++ b/.github/workflows/scripts/create_nwb_schema_version_badge.py
@@ -78,6 +78,13 @@ def main():
         default=None,
         help='Output directory for the badge (default: .github/badges/v<version>)'
     )
+    parser.add_argument(
+        '--update-latest',
+        action='store_true',
+        help='Also write the badge to .github/badges/latest. Pass this only when '
+             'releasing a version newer than every existing release, so that '
+             'rebuilding an older one does not point latest backwards.'
+    )
     
     args = parser.parse_args()
     
@@ -92,12 +99,14 @@ def main():
     
     # Set default output directory
     output_dir = args.output_dir or repo_root / '.github' / 'badges' / f'v{args.version}'
-    latest_dir = repo_root / '.github' / 'badges' / 'latest'
     
     # Get version range and create badge
     min_schema, max_schema = get_schema_version_range(schema_dir)
     create_badge(args.version, min_schema, max_schema, output_dir)
-    create_badge(args.version, min_schema, max_schema, latest_dir)
+    
+    if args.update_latest:
+        latest_dir = repo_root / '.github' / 'badges' / 'latest'
+        create_badge(args.version, min_schema, max_schema, latest_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

**Problem** — The "Prepare release" workflow is still blocked and can not produce a release. Badge generation fails with `ModuleNotFoundError: No module named 'pkg_resources'`.

Nothing in this repository changed. pybadges imports `pkg_resources`, which ships as part of setuptools, and the workflow installs the newest setuptools on every run. setuptools removed `pkg_resources` in 82.0, released 2026-02-08, so every run since then has installed a setuptools that cannot satisfy pybadges. The last successful release, v2.10.0, ran before that date. pybadges was archived in 2024, so there will be no fix upstream.

The same run exposed a second problem. Tagging ran under `if: always()`, so the workflow pushed the `v2.11.0` tag even though it had generated no badges and created no release. That tag then blocks a retry, because the next run stops at `git tag -a`.

**Solution** — Generate the badges with anybadge, which is maintained and needs neither setuptools nor `pkg_resources`. Tag only once the steps before it have succeeded, and let a retry reuse a tag that already points at the commit being released.

## Also in this PR

Reviewing the rest of the workflow turned up further ways it can go wrong. None of them caused this failure, and all are cheap to close while the file is open.

**Dispatching from a branch now rehearses instead of publishing.** The test matrix checked out the dispatched ref while the release job hardcoded `main`, so a dispatch from a feature branch tested that branch and then released `main` — a green matrix certifying code that did not ship. The release job now checks out the ref it was dispatched from, and only publishes when that ref is `main`. Dispatching from a branch still runs every step, including the version rewrite and badge generation, so it remains a useful way to check changes to this workflow before they land; it just pushes nothing and creates no release. The run summary says which mode it used.

**An already released version is rejected before the test matrix runs.** Previously the version bump reached `main` first and only the tag step objected, leaving a stray commit on a branch that takes the deploy key to correct. A tag on the current tip of `main` is still accepted, so a run that failed after tagging can still be retried.

**A changed `Contents.m` separator now fails the job instead of truncating the file.** The header is rewritten from content extracted after the dashed separator line. If that line stops matching, the extraction returns nothing and the file is replaced by its header alone, then pushed to `main` with no PR to catch it.

**Runs for a given ref are serialised**, so two dispatches cannot race on the push to `main`, the tag and the badge branch.

**The release and JUnit jobs state the permissions they need**, so both keep working if the repository default for `GITHUB_TOKEN` is ever reduced to read-only.

**The version input reaches shell steps as an environment variable** rather than being pasted in with `${{ }}`. Interpolation happens before the script runs, so a version containing a quote was parsed as code, and the format check could not prevent it because that check ran afterwards. Dispatching is limited to users with write access, so this was hardening rather than an open door. The release list for the tested-with badge moved for the same reason: it was interpolated into a Python string literal, where an apostrophe would have been a syntax error.

**anybadge is pinned**, so a new release cannot alter the badges or break the job until the pin is updated deliberately.

**The `latest/` badge is only rewritten when the version being released is newer than every existing tag.** It was rewritten on every run, so rebuilding an older release pointed `latest` at that older schema range.

## How to test

This branch can be checked with the feature it adds. Dispatch "Prepare release" from `claude/draft-release-job-issues-46f330` with a version number: the job runs end to end against this branch and publishes nothing.

The dependency failure can also be reproduced directly, in the environment the runner uses:

```bash
python3 -m venv /tmp/badge-check
/tmp/badge-check/bin/pip install --upgrade setuptools
/tmp/badge-check/bin/python -c "import pkg_resources"          # fails, as on the runner

/tmp/badge-check/bin/pip install pybadges
/tmp/badge-check/bin/python -c "from pybadges import badge"     # fails: the current workflow

/tmp/badge-check/bin/pip install anybadge
/tmp/badge-check/bin/python .github/workflows/scripts/create_nwb_schema_version_badge.py 2.11.0
```

The stale `v2.11.0` tag from the failed run has been deleted, so a release dispatch from `main` after this merges starts clean.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/matnwb/pulls) for the same change?
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
